### PR TITLE
use module-level function instead of lambda, create migrations for pending model changes

### DIFF
--- a/source/excerptexport/migrations/0004_auto_20150324_1637.py
+++ b/source/excerptexport/migrations/0004_auto_20150324_1637.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import excerptexport.models.output_file
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('excerptexport', '0003_merge'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='extractionorder',
+            name='process_reference',
+            field=models.CharField(null=True, max_length=128, blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='outputfile',
+            name='create_date',
+            field=models.DateTimeField(auto_now_add=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='outputfile',
+            name='file',
+            field=models.FileField(null=True, upload_to='/var/www/eda/projects/data', blank=True),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='outputfile',
+            name='public_identifier',
+            field=models.CharField(default=excerptexport.models.output_file.default_public_identifier, max_length=512),
+            preserve_default=True,
+        ),
+    ]

--- a/source/excerptexport/models/output_file.py
+++ b/source/excerptexport/models/output_file.py
@@ -8,12 +8,16 @@ from excerptexport import settings
 from .extraction_order import ExtractionOrder
 
 
+def default_public_identifier():
+    return str(uuid.uuid4())
+
 class OutputFile(models.Model):
+
     mime_type = models.CharField(max_length=64)
     file = models.FileField(upload_to=settings.APPLICATION_SETTINGS['data_directory'], blank=True, null=True)
     create_date = models.DateTimeField(auto_now_add=True)
     deleted_on_filesystem = models.BooleanField(default=False)
-    public_identifier = models.CharField(max_length=512, default=lambda: str(uuid.uuid4()))
+    public_identifier = models.CharField(max_length=512, default=default_public_identifier)
 
     extraction_order = models.ForeignKey(ExtractionOrder, related_name='output_files')
 


### PR DESCRIPTION
Use a module-level function instead of a lambda for model field default value. Lambdas aren't allowed, because they cannot be serialized. (`ValueError: Cannot serialize function: lambda`)

Ran
```bash
./manage.py makemigrations
```
to produce a migration for this change and previous model changes not reflected in the migrations so far.