### PR TITLE
fix and further simplify listening on all interfaces for runserver script

### DIFF
--- a/developmentEnvironment/README.md
+++ b/developmentEnvironment/README.md
@@ -103,7 +103,8 @@ to your local /etc/hosts file.
 
 ### Run application using Django built in server (see runDevelopmentServer.sh)
 
-You need to specify the ip. Otherwise you are not able to reach the application from outside of the vm.
+Specify IP `0.0.0.0` to listen on **all** interfaces. Default would be local interfaces only, so you would not be able
+to reach the application from outside of the VM.
 
 ```shell
 #!/bin/bash
@@ -111,11 +112,9 @@ You need to specify the ip. Otherwise you are not able to reach the application 
 CURRENTDIR=`dirname $0`
 cd "$CURRENTDIR"
 # activate environment
-source "../environment/bin/activate"
-# get local ip
-LOCALIP=`hostname -I`
-echo "$LOCALIP"
-python ./manage.py runserver "$LOCALIP:8000"
+source ../environment/bin/activate
+# start server listening on all interfaces
+python ./manage.py runserver 0.0.0.0:8000
 ```
 
 ### Clear Django cache

--- a/source/runDevelopmentServer.sh
+++ b/source/runDevelopmentServer.sh
@@ -2,7 +2,5 @@
 
 CURRENTDIR=`dirname $0`
 cd "$CURRENTDIR"
-source "../environment/bin/activate"
-LOCALIP=`hostname -I`
-echo "$LOCALIP"
-python ./manage.py runserver "$LOCALIP:8000"
+source ../environment/bin/activate
+python ./manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
The output of `hostname -I` has a space at the end. :-(

But we can listen on all interfaces without knowing our outside-facing IP by specifying `0.0.0.0`, anyway.

Also removed unnecessary quoting.