### PR TITLE
Feature/integrate open id authentication #14

### DIFF
--- a/developmentEnvironment/requirements.txt
+++ b/developmentEnvironment/requirements.txt
@@ -1,3 +1,4 @@
 Django>=1.8,<1.9
 django-enumfield==1.2
 psycopg2==2.6
+python-social-auth==0.2.7

--- a/source/excerptexport/templates/excerptexport/templates/access_denied.html
+++ b/source/excerptexport/templates/excerptexport/templates/access_denied.html
@@ -1,0 +1,13 @@
+{% extends "excerptexport/layouts/base.html" %}
+
+{% block main %}
+    {% if user.is_authenticated %}
+        <h2>Please contact your Administrator</h2>
+        <p>You do not appear to have the proper access rights. Pleas contact your supervisor/administrator and ask
+        for the needed access rights.</p>
+    {% else %}
+        <h2>Please Login</h2>
+        <p>This site has pages, which are protected. Please login and try again.</p>
+        <a href="{% url 'excerptexport:login' %}?next={% url 'excerptexport:index' %}">Login</a>
+    {% endif %}
+{% endblock %}

--- a/source/excerptexport/templates/excerptexport/templates/login.html
+++ b/source/excerptexport/templates/excerptexport/templates/login.html
@@ -21,4 +21,5 @@
 <input type="hidden" name="next" value="{{ next }}" />
 </form>
 
+    <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.path }}">Login with google-oauth2</a><br />
 {% endblock %}

--- a/source/excerptexport/tests/permission_test_helper.py
+++ b/source/excerptexport/tests/permission_test_helper.py
@@ -1,0 +1,19 @@
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import Permission
+from excerptexport.models import BoundingGeometry, Excerpt, ExtractionOrder
+
+
+class PermissionHelperMixin(object):
+    @staticmethod
+    def _permission_for(model, codename):
+        content_type = ContentType.objects.get_for_model(model)
+        permission = Permission.objects.get(content_type=content_type, codename=codename)
+        return permission
+
+    def add_permissions_to_user(self):
+        self.user.user_permissions.add(self._permission_for(BoundingGeometry, 'add_boundinggeometry'))
+        self.user.user_permissions.add(self._permission_for(BoundingGeometry, 'change_boundinggeometry'))
+        self.user.user_permissions.add(self._permission_for(Excerpt, 'add_excerpt'))
+        self.user.user_permissions.add(self._permission_for(Excerpt, 'change_excerpt'))
+        self.user.user_permissions.add(self._permission_for(ExtractionOrder, 'add_extractionorder'))
+        self.user.user_permissions.add(self._permission_for(ExtractionOrder, 'change_extractionorder'))

--- a/source/excerptexport/tests/test_status.py
+++ b/source/excerptexport/tests/test_status.py
@@ -4,13 +4,14 @@ from django.contrib.auth.models import User
 
 from excerptexport.models import Excerpt, ExtractionOrder, BoundingGeometry
 from excerptexport.models.extraction_order import ExtractionOrderState
+from excerptexport.tests.permission_test_helper import PermissionHelperMixin
 
 
-class StatusTestCase(TestCase):
+class StatusTestCase(TestCase, PermissionHelperMixin):
     extraction_order = None
 
     def setUp(self):
-        user = User.objects.create_user('user', 'user@example.com', 'pw')
+        self.user = user = User.objects.create_user('user', 'user@example.com', 'pw')
         self.client.login(username='user', password='pw')
 
         bounding_geometry = BoundingGeometry.create_from_bounding_box_coordinates(48, 9, 46, 6)
@@ -29,7 +30,16 @@ class StatusTestCase(TestCase):
             orderer=user
         )
 
+    def test_permission_denied_if_lacking_permissions(self):
+        response = self.client.get(
+            reverse('excerptexport:status',
+                    kwargs={'extraction_order_id': self.extraction_order.id})
+        )
+        # redirect to 'Access Denied' page
+        self.assertEqual(response.status_code, 302)
+
     def test_extraction_order_status_initialized(self):
+        self.add_permissions_to_user()
         response = self.client.get(reverse(
             'excerptexport:status',
             kwargs={'extraction_order_id': self.extraction_order.id}
@@ -40,6 +50,7 @@ class StatusTestCase(TestCase):
         self.assertContains(response, 'initialized')
 
     def test_extraction_order_status_finished(self):
+        self.add_permissions_to_user()
         self.extraction_order.state = ExtractionOrderState.FINISHED
         self.extraction_order.save()
 
@@ -53,7 +64,7 @@ class StatusTestCase(TestCase):
         self.assertContains(response, 'finished')
 
     def test_extraction_order_id_not_existing(self):
-
+        self.add_permissions_to_user()
         response = self.client.get(reverse('excerptexport:status', kwargs={'extraction_order_id': 9999999999}))
 
         self.assertEqual(response.status_code, 404)

--- a/source/excerptexport/tests/test_views.py
+++ b/source/excerptexport/tests/test_views.py
@@ -4,9 +4,10 @@ from django.test import TestCase
 
 from excerptexport.models import ExtractionOrder, Excerpt
 from excerptexport.models.bounding_geometry import BoundingGeometry
+from excerptexport.tests.permission_test_helper import PermissionHelperMixin
 
 
-class ExcerptExportViewTests(TestCase):
+class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
     user = None
     new_excerpt_post_data = None
     existing_excerpt = None
@@ -46,6 +47,7 @@ class ExcerptExportViewTests(TestCase):
         """
         When logged in, we get the excerpt choice form.
         """
+        self.add_permissions_to_user()
         self.client.login(username='user', password='pw')
         response = self.client.get(reverse('excerptexport:new'))
         self.assertEqual(response.status_code, 200)
@@ -62,6 +64,7 @@ class ExcerptExportViewTests(TestCase):
         """
         When logged in, POSTing an export request with a new excerpt is successful.
         """
+        self.add_permissions_to_user()
         self.client.login(username='user', password='pw')
         response = self.client.post(
             reverse('excerptexport:create'),
@@ -89,6 +92,7 @@ class ExcerptExportViewTests(TestCase):
         """
         When logged in, POSTing an export request using an existing excerpt is successful.
         """
+        self.add_permissions_to_user()
         self.client.login(username='user', password='pw')
         response = self.client.post(
             reverse('excerptexport:create'),
@@ -107,6 +111,7 @@ class ExcerptExportViewTests(TestCase):
         """
         When logged in, POSTing an export request with a new excerpt persists a new ExtractionOrder.
         """
+        self.add_permissions_to_user()
         self.assertEqual(ExtractionOrder.objects.count(), 0)
         self.client.login(username='user', password='pw')
         self.client.post(reverse('excerptexport:create'), self.new_excerpt_post_data, HTTP_HOST='thehost.example.com')
@@ -124,6 +129,7 @@ class ExcerptExportViewTests(TestCase):
         """
         When logged in, POSTing an export request using an existing excerpt persists a new ExtractionOrder.
         """
+        self.add_permissions_to_user()
         self.assertEqual(ExtractionOrder.objects.count(), 0)
         self.client.login(username='user', password='pw')
         self.client.post(

--- a/source/excerptexport/urls.py
+++ b/source/excerptexport/urls.py
@@ -1,21 +1,25 @@
 from django.conf.urls import patterns, url
+from excerptexport.views import index, access_denied, new_excerpt_export, show_downloads, download_file, \
+    create_excerpt_export, extraction_order_status
 
 
-urlpatterns = patterns(
-    'excerptexport.views',
-    url(r'^$', 'index', name='index'),
-    url(r'^access_denied/$', 'access_denied', name='access_denied'),
-    url(r'^new/$', 'new_excerpt_export', name='new'),
-    url(r'^downloads/$', 'show_downloads', name='downloads'),
-    url(r'^download/$', 'download_file', name='download'),
-    url(r'^create/$', 'create_excerpt_export', name='create'),
-    url(r'^orders/(?P<extraction_order_id>[0-9]+)$', 'extraction_order_status', name='status')
+except_export_urlpatterns = patterns(
+    '',
+    url(r'^$', index, name='index'),
+    url(r'^access_denied/$', access_denied, name='access_denied'),
+    url(r'^new/$', new_excerpt_export, name='new'),
+    url(r'^downloads/$', show_downloads, name='downloads'),
+    url(r'^download/$', download_file, name='download'),
+    url(r'^create/$', create_excerpt_export, name='create'),
+    url(r'^orders/(?P<extraction_order_id>[0-9]+)$', extraction_order_status, name='status')
 )
 
-urlpatterns += patterns(
+login_logout_patterns = patterns(
     '',
     url(r'^login/$', 'django.contrib.auth.views.login',
         {'template_name': 'excerptexport/templates/login.html'}, name='login'),
     url(r'^logout/$', 'django.contrib.auth.views.logout',
         {'template_name': 'excerptexport/templates/logout.html'}, name='logout'),
 )
+
+urlpatterns = except_export_urlpatterns + login_logout_patterns

--- a/source/excerptexport/urls.py
+++ b/source/excerptexport/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import patterns, url
+from django.contrib.auth.views import login, logout
 from excerptexport.views import index, access_denied, new_excerpt_export, show_downloads, download_file, \
     create_excerpt_export, extraction_order_status
 
@@ -16,9 +17,9 @@ except_export_urlpatterns = patterns(
 
 login_logout_patterns = patterns(
     '',
-    url(r'^login/$', 'django.contrib.auth.views.login',
+    url(r'^login/$', login,
         {'template_name': 'excerptexport/templates/login.html'}, name='login'),
-    url(r'^logout/$', 'django.contrib.auth.views.logout',
+    url(r'^logout/$', logout,
         {'template_name': 'excerptexport/templates/logout.html'}, name='logout'),
 )
 

--- a/source/excerptexport/urls.py
+++ b/source/excerptexport/urls.py
@@ -1,23 +1,21 @@
 from django.conf.urls import patterns, url
 
-from excerptexport import views
-
 
 urlpatterns = patterns(
+    'excerptexport.views',
+    url(r'^$', 'index', name='index'),
+    url(r'^access_denied/$', 'access_denied', name='access_denied'),
+    url(r'^new/$', 'new_excerpt_export', name='new'),
+    url(r'^downloads/$', 'show_downloads', name='downloads'),
+    url(r'^download/$', 'download_file', name='download'),
+    url(r'^create/$', 'create_excerpt_export', name='create'),
+    url(r'^orders/(?P<extraction_order_id>[0-9]+)$', 'extraction_order_status', name='status')
+)
+
+urlpatterns += patterns(
     '',
-    url(r'^$', views.index, name='index'),
-
-    url('^login/$', 'django.contrib.auth.views.login',
+    url(r'^login/$', 'django.contrib.auth.views.login',
         {'template_name': 'excerptexport/templates/login.html'}, name='login'),
-    url('^logout/$', 'django.contrib.auth.views.logout',
+    url(r'^logout/$', 'django.contrib.auth.views.logout',
         {'template_name': 'excerptexport/templates/logout.html'}, name='logout'),
-
-    url(r'^new/$', views.new_excerpt_export, name='new'),
-
-    url(r'^downloads/$', views.show_downloads, name='downloads'),
-    url(r'^download/$', views.download_file, name='download'),
-
-    url(r'^create/$', views.create_excerpt_export, name='create'),
-
-    url(r'^orders/(?P<extraction_order_id>[0-9]+)$', views.extraction_order_status, name='status')
 )

--- a/source/excerptexport/views.py
+++ b/source/excerptexport/views.py
@@ -23,14 +23,15 @@ from excerptexport.services.data_conversion_service import trigger_data_conversi
 
 def has_excerptexport_all_permissions():
     excerpt_export_permissions = [
-        'excerptexport.add_bounding_geometry',
-        'excerptexport.change_bounding_geometry',
+        'excerptexport.add_boundinggeometry',
+        'excerptexport.change_boundinggeometry',
         'excerptexport.add_excerpt',
         'excerptexport.change_excerpt',
-        'excerptexport.add_extraction_order',
-        'excerptexport.change_extraction_order',
+        'excerptexport.add_extractionorder',
+        'excerptexport.change_extractionorder',
     ]
-    # This is a simple hack, to allow a message to appear to users, that are
+    # This is a simple hack, instead of displaying a login page, it shows a permission denied page if the user is
+    # logged in
     login_url = reverse_lazy('excerptexport:access_denied')
     return permission_required(excerpt_export_permissions, login_url=login_url, raise_exception=False)
 

--- a/source/osmaxx/settings.py
+++ b/source/osmaxx/settings.py
@@ -142,7 +142,7 @@ STATIC_URL = '/static/'
 
 # login url if param 'next' is not set
 LOGIN_REDIRECT_URL = '/'
-LOGIN_URL = '/excerptexport/login'
-LOGOUT_URL = '/excerptexport/logout'
+LOGIN_URL = '/excerptexport/login/'
+LOGOUT_URL = '/excerptexport/logout/'
 
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'email']

--- a/source/osmaxx/settings.py
+++ b/source/osmaxx/settings.py
@@ -50,7 +50,57 @@ INSTALLED_APPS = (
 
 AUTHENTICATION_BACKENDS = (
     'social.backends.open_id.OpenIdAuth',
+    'social.backends.google.GoogleOpenIdConnect',
+    'social.backends.google.GoogleOpenId',
+    'social.backends.google.GoogleOAuth2',
+    'social.backends.google.GoogleOAuth',
+    'social.backends.google.GooglePlusAuth',
     'django.contrib.auth.backends.ModelBackend',
+)
+
+SOCIAL_AUTH_PIPELINE = (
+    # Get the information we can about the user and return it in a simple
+    # format to create the user instance later. On some cases the details are
+    # already part of the auth response from the provider, but sometimes this
+    # could hit a provider API.
+    'social.pipeline.social_auth.social_details',
+
+    # Get the social uid from whichever service we're authing thru. The uid is
+    # the unique identifier of the given user in the provider.
+    'social.pipeline.social_auth.social_uid',
+
+    # Verifies that the current auth process is valid within the current
+    # project, this is were emails and domains whitelists are applied (if
+    # defined).
+    'social.pipeline.social_auth.auth_allowed',
+
+    # Checks if the current social-account is already associated in the site.
+    'social.pipeline.social_auth.social_user',
+
+    # Make up a username for this person, appends a random string at the end if
+    # there's any collision.
+    'social.pipeline.user.get_username',
+
+    # Send a validation email to the user to verify its email address.
+    # Disabled by default.
+    'social.pipeline.mail.mail_validation',
+
+    # Associates the current social details with another user account with
+    # a similar email address. Disabled by default.
+    'social.pipeline.social_auth.associate_by_email',
+
+    # Create a user account if we haven't found one yet.
+    'social.pipeline.user.create_user',
+
+    # Create the record that associated the social account with this user.
+    'social.pipeline.social_auth.associate_user',
+
+    # Populate the extra_data field in the social record with the values
+    # specified by settings (and the default ones like access_token, etc).
+    'social.pipeline.social_auth.load_extra_data',
+
+    # Update the user record with any changed info from the auth service.
+    'social.pipeline.user.user_details'
 )
 
 MIDDLEWARE_CLASSES = (
@@ -144,5 +194,27 @@ STATIC_URL = '/static/'
 LOGIN_REDIRECT_URL = '/'
 LOGIN_URL = '/excerptexport/login/'
 LOGOUT_URL = '/excerptexport/logout/'
+# TODO: show nice user error page
+SOCIAL_AUTH_LOGIN_ERROR_URL = '/excerptexport/'
+# Used to redirect the user once the auth process ended successfully. The value of ?next=/foo is used if it was present
+SOCIAL_AUTH_LOGIN_REDIRECT_URL = '/excerptexport/'
+# Is used as a fallback for LOGIN_ERROR_URL
+SOCIAL_AUTH_LOGIN_URL = '/excerptexport/'
+# Used to redirect new registered users, will be used in place of SOCIAL_AUTH_LOGIN_REDIRECT_URL if defined.
+SOCIAL_AUTH_NEW_USER_REDIRECT_URL = '/excerptexport/'
+# Like SOCIAL_AUTH_NEW_USER_REDIRECT_URL but for new associated accounts (user is already logged in).
+# Used in place of SOCIAL_AUTH_LOGIN_REDIRECT_URL
+SOCIAL_AUTH_NEW_ASSOCIATION_REDIRECT_URL = '/excerptexport/'
+# The user will be redirected to this URL when a social account is disconnected
+SOCIAL_AUTH_DISCONNECT_REDIRECT_URL = '/excerptexport/'
+# Inactive users can be redirected to this URL when trying to authenticate.
+# Successful URLs will default to SOCIAL_AUTH_LOGIN_URL while error URLs will fallback to SOCIAL_AUTH_LOGIN_ERROR_URL.
+SOCIAL_AUTH_INACTIVE_USER_URL = '/excerptexport/'
+SOCIAL_AUTH_LOGIN_SUCCESS_URL = '/excerptexport/'
 
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'email']
+
+# TODO: remove these insecure settings and move them out of the repository!
+# registered for localhost, localhost:8000 and localhost:8080 only!
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = '126950426483-l14itbjtoge7iobol097m2lk0brhu1si.apps.googleusercontent.com'
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = 'ojL6tk6NuNC6XVHCvO0nnV8F'

--- a/source/osmaxx/settings.py
+++ b/source/osmaxx/settings.py
@@ -42,7 +42,15 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.gis',
-    'excerptexport'
+
+    'social.apps.django_app.default',
+
+    'excerptexport',
+)
+
+AUTHENTICATION_BACKENDS = (
+    'social.backends.open_id.OpenIdAuth',
+    'django.contrib.auth.backends.ModelBackend',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -54,6 +62,26 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': (
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.debug",
+                "django.template.context_processors.i18n",
+                "django.template.context_processors.media",
+                "django.template.context_processors.static",
+                "django.template.context_processors.tz",
+                'social.apps.django_app.context_processors.backends',
+                'social.apps.django_app.context_processors.login_redirect',
+                "django.contrib.messages.context_processors.messages",
+            )
+        }
+    },
+]
 
 CACHES = {
     'default': {
@@ -112,6 +140,6 @@ STATIC_URL = '/static/'
 #     os.path.join(BASE_DIR, 'resources/public/'),
 # )
 
- # login url if param 'next' is not set
+# login url if param 'next' is not set
 LOGIN_REDIRECT_URL = '/'
 LOGIN_URL = '/login'

--- a/source/osmaxx/settings.py
+++ b/source/osmaxx/settings.py
@@ -142,4 +142,7 @@ STATIC_URL = '/static/'
 
 # login url if param 'next' is not set
 LOGIN_REDIRECT_URL = '/'
-LOGIN_URL = '/login'
+LOGIN_URL = '/excerptexport/login'
+LOGOUT_URL = '/excerptexport/logout'
+
+SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'email']

--- a/source/osmaxx/urls.py
+++ b/source/osmaxx/urls.py
@@ -4,6 +4,8 @@ from django.contrib import admin
 from social.apps.django_app import urls as social_urls
 
 from excerptexport import urls as excerptexport_urls
+
+
 urlpatterns = patterns(
     '',
     # Examples:

--- a/source/osmaxx/urls.py
+++ b/source/osmaxx/urls.py
@@ -1,15 +1,17 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 
+from social.apps.django_app import urls as social_urls
 
+from excerptexport import urls as excerptexport_urls
 urlpatterns = patterns(
     '',
     # Examples:
     # url(r'^$', 'osmaxx.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
-    url(r'^excerptexport/', include('excerptexport.urls', namespace='excerptexport')),
+    url(r'^excerptexport/', include(excerptexport_urls, namespace='excerptexport')),
     url(r'^admin/', include(admin.site.urls)),
 
-    url('', include('social.apps.django_app.urls', namespace='social')),
+    url('', include(social_urls, namespace='social')),
 )

--- a/source/osmaxx/urls.py
+++ b/source/osmaxx/urls.py
@@ -11,5 +11,5 @@ urlpatterns = patterns(
     url(r'^excerptexport/', include('excerptexport.urls', namespace='excerptexport')),
     url(r'^admin/', include(admin.site.urls)),
 
-    url('', include('social.apps.django_app.urls', namespace='social'))
+    url('', include('social.apps.django_app.urls', namespace='social')),
 )

--- a/source/osmaxx/urls.py
+++ b/source/osmaxx/urls.py
@@ -10,4 +10,6 @@ urlpatterns = patterns(
 
     url(r'^excerptexport/', include('excerptexport.urls', namespace='excerptexport')),
     url(r'^admin/', include(admin.site.urls)),
+
+    url('', include('social.apps.django_app.urls', namespace='social'))
 )


### PR DESCRIPTION
* Login with google oauth
* Some cleanup
* Circular dependencies resolved with the urls.py

**Warning**: Login in Settings with oauth for testing purposes only and localhost only!

Tested Application:
```sh
./manage.py check
./manage.py test
```
Application manually Tested:
* login through google oauth
* get permission denied for views
* add rights as admin to user
* access views with permissions

@das-g & @wasabideveloper please review