### PR TITLE
exclude all migrations from flake8 linting/QA

### DIFF
--- a/source/excerptexport/migrations/0001_initial.py
+++ b/source/excerptexport/migrations/0001_initial.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# don't check for validation errors in auto-generated migration file
-# flake8: noqa
 from __future__ import unicode_literals
 
 from django.db import models, migrations

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [flake8]
 # ignore = E226,E302,E41
 max-line-length = 119
-# exclude = tests/*
+exclude = **/source/*/migrations/*
 # max-complexity = 10


### PR DESCRIPTION
Excluding each new or overwritten migration file individually from flake8 is unnecessary busywork. Instead, let's exclude them all.

The `**/` prefix is needed so excluding works in the git hook, too. (I think this is a bug in the hook.)