### PR TITLE
Feature/fix locales compilation and environment warning for development container #135

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,8 @@ Then initiate the project defaults:
 
 Inside the container:
 
-1. Install dependencies: `$ pip3 install -r requirements/local.txt`
-2. Execute migrations: `$ python3 manage.py migrate`
-3. (optional, recommended) setup a superuser: `$ python3 manage.py createsuperuser`
+1. Execute migrations: `$ python3 manage.py migrate`
+2. (optional, recommended) setup a superuser: `$ python3 manage.py createsuperuser`
 
 ### Running the project
 

--- a/osmaxx-py/config/settings/local.py
+++ b/osmaxx-py/config/settings/local.py
@@ -9,7 +9,7 @@ TEMPLATE_DEBUG = DEBUG
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 # Note: This key only used for development and testing.
-SECRET_KEY = env("DJANGO_SECRET_KEY", default='CHANGEME!!!')
+SECRET_KEY = env.str("DJANGO_SECRET_KEY", default='CHANGEME!!!')
 
 # Mail settings
 # ------------------------------------------------------------------------------

--- a/osmaxx-py/config/settings/production.py
+++ b/osmaxx-py/config/settings/production.py
@@ -14,7 +14,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
 ) + MIDDLEWARE_CLASSES
 
-SECRET_KEY = env("DJANGO_SECRET_KEY")
+SECRET_KEY = env.str("DJANGO_SECRET_KEY")
 
 # SSL CONFIGURATION
 # set this to 60 seconds and then to 518400 when you can prove it works

--- a/osmaxx-py/manage.py
+++ b/osmaxx-py/manage.py
@@ -5,11 +5,9 @@ import sys
 import environ
 
 if __name__ == "__main__":
-    try:
+    if os.path.exists('.env'):
         env = environ.Env
         env.read_env('.env')
-    except FileNotFoundError:
-        pass
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
 
     from django.core.management import execute_from_command_line

--- a/osmaxx-py/osmaxx/third_party_apps/stored_messages/migrations/0002_message_url.py
+++ b/osmaxx-py/osmaxx/third_party_apps/stored_messages/migrations/0002_message_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stored_messages', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='message',
+            name='url',
+            field=models.URLField(blank=True, null=True),
+        ),
+    ]

--- a/osmaxx-py/requirements/base.txt
+++ b/osmaxx-py/requirements/base.txt
@@ -3,9 +3,7 @@ Django>=1.8,<1.9
 django-enumfield==1.2.1
 django-environ==0.3.0
 django-secure==1.0.1
--e git+https://github.com/evonove/django-stored-messages.git@master#egg=django-stored-messages
-# TODO: remove github link and replace with fixed version when available
-#django-stored-messages==1.1.0
+django-stored-messages==1.3.0
 
 psycopg2==2.6.1
 python-social-auth==0.2.11


### PR DESCRIPTION
closes #135.

* Don't read .env if not available
* Upgrade django-stored-messages to remove direct link to repository.

Did:
* Ran tests
* ran checks
-> all good