### PR TITLE
Feature/fix ie button group style

### DIFF
--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
@@ -26,8 +26,13 @@
             formPartsSwitcher.value = formModeParam;
         }
 
+        // IE may throw an error here "Object doesn't support this action".
+        // It seems IE won't trigger a change event on select boxes
+        // I didn't found a solution to get the supported actions,
+        // so the error is still there: Fuck you IE
+        // Note: The switcher is working anyway
         formPartsSwitcher.dispatchEvent(new Event('change'));
-    }
+    };
 
     window.addEventListener('load', function() {
         var formPartNodes = document.querySelectorAll('[data-form-part]');
@@ -47,6 +52,11 @@
 
             if(formPartsSwitcher.value != formPartId) {
                 formPartsSwitcher.value = formPartId;
+                // IE may throw an error here "Object doesn't support this action".
+                // It seems IE won't trigger a change event on select boxes
+                // I didn't found a solution to get the supported actions,
+                // so the error is still there: Fuck you IE
+                // Note: The switcher is working anyway
                 formPartsSwitcher.dispatchEvent(new Event('change'));
             }
         };

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
@@ -27,10 +27,10 @@
         }
 
         // IE may throw an error here "Object doesn't support this action".
-        // It seems IE won't trigger a change event on select boxes
-        // I didn't found a solution to get the supported actions,
-        // so the error is still there: Fuck you IE
-        // Note: The switcher is working anyway
+        // It seems IE won't trigger a change event on select boxes.
+        // I didn't find a solution to get the supported actions,
+        // so the error is still there: Fuck you IE.
+        // Note: The switcher is working regardless.
         formPartsSwitcher.dispatchEvent(new Event('change'));
     };
 
@@ -53,10 +53,10 @@
             if(formPartsSwitcher.value != formPartId) {
                 formPartsSwitcher.value = formPartId;
                 // IE may throw an error here "Object doesn't support this action".
-                // It seems IE won't trigger a change event on select boxes
-                // I didn't found a solution to get the supported actions,
-                // so the error is still there: Fuck you IE
-                // Note: The switcher is working anyway
+                // It seems IE won't trigger a change event on select boxes.
+                // I didn't find a solution to get the supported actions,
+                // so the error is still there: Fuck you IE.
+                // Note: The switcher is working regardless.
                 formPartsSwitcher.dispatchEvent(new Event('change'));
             }
         };

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
@@ -29,7 +29,7 @@
         // IE may throw an error here "Object doesn't support this action".
         // It seems IE won't trigger a change event on select boxes.
         // I didn't find a solution to get the supported actions,
-        // so the error is still there: Fuck you IE.
+        // so the error is still there: Use a better browser.
         // Note: The switcher is working regardless.
         formPartsSwitcher.dispatchEvent(new Event('change'));
     };
@@ -55,7 +55,7 @@
                 // IE may throw an error here "Object doesn't support this action".
                 // It seems IE won't trigger a change event on select boxes.
                 // I didn't find a solution to get the supported actions,
-                // so the error is still there: Fuck you IE.
+                // so the error is still there: Use a better browser.
                 // Note: The switcher is working regardless.
                 formPartsSwitcher.dispatchEvent(new Event('change'));
             }

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/formModeSwitcher.js
@@ -30,7 +30,7 @@
         // It seems IE won't trigger a change event on select boxes.
         // I didn't find a solution to get the supported actions,
         // so the error is still there: Use a better browser.
-        // Note: The switcher is working regardless.
+        // Note: The switcher is working on IE but IE users don't have the same features as other users
         formPartsSwitcher.dispatchEvent(new Event('change'));
     };
 
@@ -56,7 +56,7 @@
                 // It seems IE won't trigger a change event on select boxes.
                 // I didn't find a solution to get the supported actions,
                 // so the error is still there: Use a better browser.
-                // Note: The switcher is working regardless.
+                // Note: The switcher is working on IE but IE users don't have the same features as other users
                 formPartsSwitcher.dispatchEvent(new Event('change'));
             }
         };

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/ie-fixes.css
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/ie-fixes.css
@@ -1,6 +1,6 @@
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    /* readd IE default style to reatyle it isable for IE uesers
-     * IE does not support styling for select and option as buttons :-(
+    /* Re-add IE default style to restyle it isable for IE uesers, as
+     * IE does not support styling for select and option as buttons. :-(
      */
     select.btn-group, .select-button-group > select.btn-group {
         font-size: 1.5rem !important;

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/ie-fixes.css
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/ie-fixes.css
@@ -1,0 +1,18 @@
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    /* readd IE default style to reatyle it isable for IE uesers
+     * IE does not support styling for select and option as buttons :-(
+     */
+    select.btn-group, .select-button-group > select.btn-group {
+        font-size: 1.5rem !important;
+        display: block;
+        width: auto!important;
+        border: 1px solid rgb(33,33,33) !important;
+    }
+    select.btn-group > option:checked {
+        border-color: none;
+        background-color: rgb(51, 152, 254);
+    }
+    select.btn-group > option {
+        font-size: 1.5rem !important;
+    }
+}

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/ie-fixes.css
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/ie-fixes.css
@@ -1,5 +1,5 @@
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-    /* Re-add IE default style to restyle it isable for IE uesers, as
+    /* Re-add IE default style to restyle it usable for IE users, as
      * IE does not support styling for select and option as buttons. :-(
      */
     select.btn-group, .select-button-group > select.btn-group {

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/main.css
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/stylesheets/main.css
@@ -140,9 +140,7 @@ optgroup:before {
     display:inline-block;
     border: none;
     background: none;
-    background: none;
     -moz-appearance: none;
-    -ms-appearance: none;
     -webkit-appearance: none;
     appearance: none;
     overflow: hidden;

--- a/osmaxx-py/osmaxx/excerptexport/templates/excerptexport/layouts/base.html
+++ b/osmaxx-py/osmaxx/excerptexport/templates/excerptexport/layouts/base.html
@@ -15,6 +15,7 @@
     <link rel='stylesheet' type='text/css' href='{% static "excerptexport/libraries/leaflet-locationfilter/src/locationfilter.css" %}' />
 
     <link rel='stylesheet' type='text/css' href='{% static "excerptexport/stylesheets/main.css" %}' />
+    <link rel='stylesheet' type='text/css' href='{% static "excerptexport/stylesheets/ie-fixes.css" %}' />
 </head>
 <body>
     <div class="page">


### PR DESCRIPTION
Bugfix of #140 (closes #140 ).

* ran tests
* tested views by hand (IE, FF):
  * /orders/new/
  * /orders/{orderId}

Reviewed by:
- [x] @das-g 
- [x] @njordan-hsr 

It's not possible to fix the issue, but I improved the visual appereance as much as possible:

**Firefox**:
![buttonsffchrome](https://cloud.githubusercontent.com/assets/10944699/9308831/7d3e3910-4506-11e5-813e-71ff9b748249.png)

**Internet Explorer**:
![buttonsie](https://cloud.githubusercontent.com/assets/10944699/9308832/7d3faa7a-4506-11e5-936f-2b3d1022e7ce.png)

It's not possible to fix the JS exception "Object doesn't support action" because there is no possibility to detect allowed actions by JS (crappy IE disables actions but does not allow to check that before calling an action).