### PR TITLE
Add mailto link to request access for osmaxx

### DIFF
--- a/osmaxx-py/config/settings/common.py
+++ b/osmaxx-py/config/settings/common.py
@@ -106,10 +106,6 @@ ADMINS = ()
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#managers
 MANAGERS = ADMINS
 
-# The email adress of this user will be used to generate the mailto link for users
-# to request access to osmaxx (access_denied page)
-ACCOUNT_MANAGER_USERNAME = 'admin'
-
 # DATABASE CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
@@ -374,4 +370,10 @@ MESSAGE_TAGS = {
     25: 'success',
     30: 'warning',
     40: 'error'
+}
+
+OSMAXX = {
+    # The email adress of this user will be used to generate the mailto link for users
+    # to request access to osmaxx (access_denied page)
+    'account_manager_username': 'admin'
 }

--- a/osmaxx-py/config/settings/common.py
+++ b/osmaxx-py/config/settings/common.py
@@ -375,5 +375,5 @@ MESSAGE_TAGS = {
 OSMAXX = {
     # The email adress of this user will be used to generate the mailto link for users
     # to request access to osmaxx (access_denied page)
-    'account_manager_username': 'admin'
+    'account_manager_username': env.str('ACCOUNT_MANAGER_USERNAME', default='admin')
 }

--- a/osmaxx-py/config/settings/common.py
+++ b/osmaxx-py/config/settings/common.py
@@ -106,6 +106,10 @@ ADMINS = ()
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#managers
 MANAGERS = ADMINS
 
+# The email adress of this user will be used to generate the mailto link for users
+# to request access to osmaxx (access_denied page)
+ACCOUNT_MANAGER_USERNAME = 'admin'
+
 # DATABASE CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases

--- a/osmaxx-py/osmaxx/excerptexport/templates/excerptexport/templates/access_denied.html
+++ b/osmaxx-py/osmaxx/excerptexport/templates/excerptexport/templates/access_denied.html
@@ -10,6 +10,13 @@
                 {% blocktrans %}You do not appear to have the proper access rights. Please contact your
                 supervisor/administrator and ask for the needed access rights.{% endblocktrans %}
             </p>
+            <p>
+                {% blocktrans %}If you created a new account, you need to request for activation: {% endblocktrans %}<br />
+                <a href="mailto:{{ admin_user.email }}?subject={% trans 'Request%20access%20for%20Osmaxx' %}&body={% blocktrans with username=user.username %}Hello%20Osmaxx%20Admin%0D%0A%0D%0AI%20would%20like%20to%20use%20Osmaxx.%20Please%20activate%20my%20account%20'{{ username }}'.%0D%0A%0D%0AThanks%0D%0A{% endblocktrans %}">
+                    <button>&#9993; {% trans 'Request access' %}</button>
+                </a>
+                {% blocktrans with next=next_page %}and try <a href="{{ next_page }}">again</a>.{% endblocktrans %}
+            </p>
         {% else %}
             <h2>{% trans 'Please Login' %}</h2>
             <p>{% trans 'This site has pages, which are protected. Please login and try again.' %}</p>

--- a/osmaxx-py/osmaxx/excerptexport/urls.py
+++ b/osmaxx-py/osmaxx/excerptexport/urls.py
@@ -7,14 +7,14 @@ from osmaxx.excerptexport.views import (
     download_file,
     extraction_order_status,
     list_orders,
-    NewExtractionOrderView
+    NewExtractionOrderView,
+    access_denied
 )
 
 
 except_export_urlpatterns = [
     url(r'^$', TemplateView.as_view(template_name="excerptexport/templates/index.html"), name='index'),
-    url(r'^access_denied/$', TemplateView.as_view(template_name="excerptexport/templates/access_denied.html"),
-        name='access_denied'),
+    url(r'^access_denied/$', access_denied, name='access_denied'),
 
     url(r'^downloads/$', list_downloads, name='downloads'),
     url(r'^downloads/(?P<uuid>[A-Za-z0-9_-]+)/$', download_file, name='download'),

--- a/osmaxx-py/osmaxx/excerptexport/urls.py
+++ b/osmaxx-py/osmaxx/excerptexport/urls.py
@@ -8,7 +8,7 @@ from osmaxx.excerptexport.views import (
     extraction_order_status,
     list_orders,
     NewExtractionOrderView,
-    access_denied
+    access_denied,
 )
 
 

--- a/osmaxx-py/osmaxx/excerptexport/views.py
+++ b/osmaxx-py/osmaxx/excerptexport/views.py
@@ -176,10 +176,13 @@ def list_orders(request):
 
 
 def access_denied(request):
+    admin_user_name = settings.OSMAXX['account_manager_username']
+
     view_context = {
         'next_page': request.GET['next'],
         'user': request.user,
-        'admin_user': User.objects.get(username=settings.ACCOUNT_MANAGER_USERNAME)
+        'admin_user': User.objects.get(username=admin_user_name) if
+        User.objects.filter(username=admin_user_name).exists() == 1 else None
     }
     return render_to_response('excerptexport/templates/access_denied.html', context=view_context,
                               context_instance=RequestContext(request))

--- a/osmaxx-py/osmaxx/excerptexport/views.py
+++ b/osmaxx-py/osmaxx/excerptexport/views.py
@@ -6,9 +6,11 @@ from django.core.servers.basehttp import FileWrapper
 from django.core.urlresolvers import reverse
 from django.template import RequestContext
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View
+from django.conf import settings
 
 from .models import ExtractionOrder, Excerpt, OutputFile, BBoxBoundingGeometry
 from .models.extraction_order import ExtractionOrderState
@@ -170,4 +172,14 @@ def list_orders(request):
         .order_by('-id')[:excerptexport_settings.APPLICATION_SETTINGS['orders_history_number_of_items']]
     }
     return render_to_response('excerptexport/templates/list_orders.html', context=view_context,
+                              context_instance=RequestContext(request))
+
+
+def access_denied(request):
+    view_context = {
+        'next_page': request.GET['next'],
+        'user': request.user,
+        'admin_user': User.objects.get(username=settings.ACCOUNT_MANAGER_USERNAME)
+    }
+    return render_to_response('excerptexport/templates/access_denied.html', context=view_context,
                               context_instance=RequestContext(request))


### PR DESCRIPTION
Implementation of feature #182 (Merge will close #182 ).
<hr />
![osmaxxmail1](https://cloud.githubusercontent.com/assets/10944699/9934814/db915140-5d53-11e5-9893-ccfb20fdb4ae.png)
<hr />
![osmaxxmail](https://cloud.githubusercontent.com/assets/10944699/9934810/d7f9704e-5d53-11e5-97e7-7409956ac927.png)
<hr />

* locales **not** compiled
* ran tests
* tested views by hand:
  * /access_denied/
* created an email account: see owncloud

To be reviewed by:
- [ ] @das-g 
- [x] @njordan-hsr 