### PR TITLE
Feature/192 handle removal of application containers in setup.production.sh

### DIFF
--- a/compose-production.yml
+++ b/compose-production.yml
@@ -1,3 +1,5 @@
+# INFO: remember to update the setup.production.sh if you change something here.
+
 shareddata:
   image: buildpack-deps:jessie
   command: /bin/true

--- a/setup.production.sh
+++ b/setup.production.sh
@@ -10,16 +10,20 @@ docker create --name osmaxx-starter -v "$(pwd):/app"  -v "/var/run/docker.sock:/
 
 # stop containers & cleanup
 docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" stop
-# FIXME: data containers should not be removed!
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" rm -f
+# remove all containers explicitly except the data container
+docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" \
+rm -f webapp rabbitmq celery database email
 
 # pull & build
 docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" pull
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" build
+# build all containers explicitly except the data container
+docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" \
+build webapp rabbitmq celery database email
 
 # migrate
 docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" up -d database
 sleep 10
+# FIXME: create superuser should only be needed to be ran once.
 docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" -it --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" \
     run --rm webapp /bin/bash -c "python3 manage.py migrate && python3 manage.py createsuperuser"
 docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" stop

--- a/setup.production.sh
+++ b/setup.production.sh
@@ -10,7 +10,7 @@ docker create --name osmaxx-starter -v "$(pwd):/app"  -v "/var/run/docker.sock:/
 
 # stop containers & cleanup
 docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" stop
-# TODO: data containers should not be removed!
+# FIXME: data containers should not be removed!
 docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" rm -f
 
 # pull & build

--- a/setup.production.sh
+++ b/setup.production.sh
@@ -5,25 +5,36 @@
 
 DOCKER_COMPOSE_TAG="1.3.1"
 
+CONTAINERS_TO_BE_UPDATED='webapp celery'
+
+function run_docker_compose_dduportal() {
+ docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:${DOCKER_COMPOSE_TAG}" "${@}"
+}
+function run_docker_compose_dduportal_interactive() {
+    docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" -it --rm "dduportal/docker-compose:${DOCKER_COMPOSE_TAG}" "${@}"
+}
+
 # create container
-docker create --name osmaxx-starter -v "$(pwd):/app"  -v "/var/run/docker.sock:/var/run/docker.sock"  -e "COMPOSE_PROJECT_NAME=osmaxx" "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" up --no-recreate
+docker create --name osmaxx-starter -v "$(pwd):/app"  -v "/var/run/docker.sock:/var/run/docker.sock"  -e "COMPOSE_PROJECT_NAME=osmaxx" "dduportal/docker-compose:${DOCKER_COMPOSE_TAG}" up --no-recreate
 
 # stop containers & cleanup
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" stop
+run_docker_compose_dduportal stop
+
 # remove all containers explicitly except the data container
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" \
-rm -f webapp rabbitmq celery database email
+run_docker_compose_dduportal rm -f ${CONTAINERS_TO_BE_UPDATED}
 
 # pull & build
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" pull
+run_docker_compose_dduportal pull
+
 # build all containers explicitly except the data container
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" \
-build webapp rabbitmq celery database email
+run_docker_compose_dduportal build ${CONTAINERS_TO_BE_UPDATED}
 
 # migrate
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" up -d database
+run_docker_compose_dduportal up -d database
+
 sleep 10
-# FIXME: create superuser should only be needed to be ran once.
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" -it --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" \
-    run --rm webapp /bin/bash -c "python3 manage.py migrate && python3 manage.py createsuperuser"
-docker run -v "$(pwd):/app" -v "/var/run/docker.sock:/var/run/docker.sock" -e "COMPOSE_PROJECT_NAME=osmaxx" --rm "dduportal/docker-compose:$DOCKER_COMPOSE_TAG" stop
+
+# FIXME: create superuser should only be needed to be ran once per deployment setup.
+run_docker_compose_dduportal_interactive run --rm webapp /bin/bash -c "python3 manage.py migrate && python3 manage.py createsuperuser"
+
+run_docker_compose_dduportal stop


### PR DESCRIPTION
Closes #192 

* delete all containers _except_ the data container.

Ran tests with `RUN_E2E=true ./test.sh`: all green.

Reviewed by:
* [ ] @das-g 
* [x] @wasabideveloper 