### PR TITLE
run osmaxx-py/manage.py makemigrations

### DIFF
--- a/osmaxx-py/osmaxx/excerptexport/migrations/0009_auto_20151130_1414.py
+++ b/osmaxx-py/osmaxx/excerptexport/migrations/0009_auto_20151130_1414.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('excerptexport', '0008_extractionorder_process_id'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='extractionorder',
+            name='process_id',
+            field=models.TextField(null=True, blank=True, verbose_name='process link'),
+        ),
+    ]


### PR DESCRIPTION
For a [subtle model change](https://github.com/geometalab/osmaxx/commit/b9bc56a0c0ae5ec6c2e3df9619c968bb0fa39c47#diff-2f2fab63c402770e035d997760c4aa42R28) migrations had not been created, which is hereby done.

Reviewed by:
- [x] @hixi 