### PR TITLE
Feature/318 disable garmin export option when a country is selected

### DIFF
--- a/osmaxx-py/fixtures/vcr/views-test_create_with_country_when_garmin_selected_is_invalid.yml
+++ b/osmaxx-py/fixtures/vcr/views-test_create_with_country_when_garmin_selected_is_invalid.yml
@@ -1,0 +1,49 @@
+interactions:
+- request:
+    body: !!binary |
+      eyJwYXNzd29yZCI6ICJkZXYiLCAidXNlcm5hbWUiOiAiZGV2IiwgIm5leHQiOiAiaHR0cDovL2xv
+      Y2FsaG9zdDo4OTAxL2FwaS8ifQ==
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['76']
+      Content-Type: [application/json; charset=UTF-8]
+      Referer: ['http://localhost:8901/api/token-auth/']
+      User-Agent: [python-requests/2.6.2 CPython/3.4.2 Linux/3.16.0-4-amd64]
+    method: POST
+    uri: http://localhost:8901/api/token-auth/
+  response:
+    body: {string: '{"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IiIsInVzZXJfaWQiOjEsImV4cCI6MTQ1MDE5NzQ4OSwidXNlcm5hbWUiOiJkZXYifQ.gyxSxLmlz77GWzXZBnBC4PfHIIfQXw2F__tNJwD-_B8"}'}
+    headers:
+      Allow: ['POST, OPTIONS']
+      Connection: [close]
+      Content-Type: [application/json]
+      Date: ['Tue, 15 Dec 2015 16:33:09 GMT']
+      Server: [Werkzeug/0.10.4 Python/3.4.3]
+      Vary: [Accept]
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [JWT eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IiIsInVzZXJfaWQiOjEsImV4cCI6MTQ1MDE5NzQ4OSwidXNlcm5hbWUiOiJkZXYifQ.gyxSxLmlz77GWzXZBnBC4PfHIIfQXw2F__tNJwD-_B8]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=UTF-8]
+      User-Agent: [python-requests/2.6.2 CPython/3.4.2 Linux/3.16.0-4-amd64]
+    method: GET
+    uri: http://localhost:8901/api/country/
+  response:
+    body: {string: "[{\"id\":237,\"name\":\"Monaco\"}]"}
+    headers:
+      Allow: ['GET, HEAD, OPTIONS']
+      Connection: [close]
+      Content-Type: [application/json]
+      Date: ['Tue, 15 Dec 2015 16:33:09 GMT']
+      Server: [Werkzeug/0.10.4 Python/3.4.3]
+      Vary: ['Accept, Cookie']
+      X-Frame-Options: [SAMEORIGIN]
+    status: {code: 200, message: OK}
+version: 1

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/map.js
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/map.js
@@ -94,6 +94,9 @@
                 if (that.country !== null) {
                     map.removeLayer(that.country);
                 }
+                // FIXME: dirty hack to hide the garmin export option
+                jQuery('#id_formats_5').parent().hide();
+
                 that.locationFilter.disable();
                 that.country = that.selectedExcerptGeoJson;
                 map.addLayer(that.country);
@@ -104,6 +107,9 @@
                 if (that.country !== null) {
                     map.removeLayer(that.country);
                 }
+                // FIXME: dirty hack to show the garmin export option
+                jQuery('#id_formats_5').parent().show();
+
                 that.locationFilter.enable();
                 that.locationFilter.setBounds(geometry.getBounds());
                 map.fitBounds(that.locationFilter.getBounds());

--- a/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/map.js
+++ b/osmaxx-py/osmaxx/excerptexport/static/excerptexport/scripts/map.js
@@ -95,7 +95,9 @@
                     map.removeLayer(that.country);
                 }
                 // FIXME: dirty hack to hide the garmin export option
-                jQuery('#id_formats_5').parent().hide();
+                var garminCheckbox = jQuery('#id_formats_5');
+                garminCheckbox.checked = false;
+                garminCheckbox.parent().hide();
 
                 that.locationFilter.disable();
                 that.country = that.selectedExcerptGeoJson;

--- a/osmaxx-py/osmaxx/excerptexport/tests/test_views.py
+++ b/osmaxx-py/osmaxx/excerptexport/tests/test_views.py
@@ -200,3 +200,20 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         self.assertDictEqual(newly_created_order.extraction_configuration, self.existing_excerpt_extraction_options)
         self.assertEqual(newly_created_order.orderer, self.user)
         self.assertEqual(newly_created_order.excerpt.name, 'Some old Excerpt')
+
+    @vcr.use_cassette('fixtures/vcr/views-test_create_with_country_when_garmin_selected_is_invalid.yml')
+    def test_create_with_country_when_garmin_selected_is_invalid(self):
+        self.add_permissions_to_user()
+        self.client.login(username='user', password='pw')
+        country_id = 'country-237'  # country id from recorded test
+        country_post_data = {
+            'form_mode': 'existing-excerpt',
+            'existing_excerpts': country_id,
+            'formats': ['garmin'],
+        }
+        response = self.client.post(
+            reverse('excerptexport:new'),
+            country_post_data,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'The Garmin export option is not available for countries.')


### PR DESCRIPTION
- Validation on server side (form) and some help with javascript for the user

Dirty hacks in Javascript for now - didn't know of a quick _and_ clean solution.

Reviewed by:

- [x] @wasabideveloper 
- [x] @das-g 

Closes #318 