### PR TITLE
update references to this repository after it has been renamed on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/geometalab/osmaxx-frontend.svg?branch=master)](https://travis-ci.org/geometalab/osmaxx-frontend) ([branch `master`](https://github.com/geometalab/osmaxx-frontend/tree/master))
+[![Build Status](https://travis-ci.org/geometalab/osmaxx.svg?branch=master)](https://travis-ci.org/geometalab/osmaxx) ([branch `master`](https://github.com/geometalab/osmaxx/tree/master))
 
 Django-based Web Frontend for **osmaxx**.
 
@@ -6,7 +6,7 @@ For deploying a complete **osmaxx** setup, see https://github.com/geometalab/osm
 
 ## Development
 
-[![Build Status](https://travis-ci.org/geometalab/osmaxx-frontend.svg?branch=develop)](https://travis-ci.org/geometalab/osmaxx-frontend) ([branch `develop`](https://github.com/geometalab/osmaxx-frontend/tree/develop))
+[![Build Status](https://travis-ci.org/geometalab/osmaxx.svg?branch=develop)](https://travis-ci.org/geometalab/osmaxx) ([branch `develop`](https://github.com/geometalab/osmaxx/tree/develop))
 
 * [Project Repository (Git)](/docs/git-repository.md)
 * [Project Development Environment (Docker)](/docs/project-development-environment.md)

--- a/docs/git-repository.md
+++ b/docs/git-repository.md
@@ -4,7 +4,7 @@ For developers have write access to this repository:
 
 1. Clone this GitHub repository to your local machine and change into the local repo
 	```shell
-	git clone git@github.com:geometalab/osmaxx-frontend.git osmaxx && cd osmaxx-frontend
+	git clone git@github.com:geometalab/osmaxx.git osmaxx && cd osmaxx
 	```
 	You can specify the name of the remote origin by adding param -o. Example: `-o 'gitHub'`
 


### PR DESCRIPTION
The occurences of the string 'osmaxx-frontend' [in `build_and_push_images.py`](https://github.com/geometalab/osmaxx/blob/b5d5dfb91eb068ebf05018d6aecdbf43e6c19cc9/build_and_push_images.py#L7) and [in `docker-compose.yml`](https://github.com/geometalab/osmaxx/blob/b5d5dfb91eb068ebf05018d6aecdbf43e6c19cc9/docker-compose.yml#L15) are left alone, as they refer to the Docker Hub image name, not the GitHub repository.

### Reviewed by
- [x] @hixi