### PR TITLE
"Wambacher" instead of "Mr. Wambacher"

### DIFF
--- a/osmaxx/core/templates/pages/about_us.html
+++ b/osmaxx/core/templates/pages/about_us.html
@@ -50,7 +50,7 @@
     <h5>Country Boundaries</h5>
     <p>
         We are using the country boundaries that are based on OSM-Data,
-        cleaned and maintained by <a href="https://osm.wno-edv-service.de/boundaries/">Mr. Wambacher</a>.
+        cleaned and maintained by <a href="https://osm.wno-edv-service.de/boundaries/">Wambacher</a>.
     </p>
 </div>
 {% endblock %}


### PR DESCRIPTION
"Wambacher" seems to be Walter's pseudonym/nickname, not his last name.

### Reviewed by
- [x] @hixi
- [ ] @sfkeller