### PR TITLE
Feature/push master when releasing

### DIFF
--- a/release.py
+++ b/release.py
@@ -90,7 +90,7 @@ def make_release_specific_changes(release_version):
 def release_finish(release_version):
     execute_steps([
         ["git", "flow", "release", "finish", release_version, "-m", "'OSMaxx release {}'".format(release_version)],
-        ["git", "push", "origin", "develop:develop", "master:master", "--tags"],
+        ["git", "push", "origin", "develop:develop", "master:master", release_version],
     ])
     build_and_push_images(release_version)
 

--- a/release.py
+++ b/release.py
@@ -90,8 +90,7 @@ def make_release_specific_changes(release_version):
 def release_finish(release_version):
     execute_steps([
         ["git", "flow", "release", "finish", release_version, "-m", "'OSMaxx release {}'".format(release_version)],
-        "git push",
-        "git push --tags",
+        ["git", "push", "origin", "develop:develop", "master:master", "--tags"],
     ])
     build_and_push_images(release_version)
 


### PR DESCRIPTION
* push `master` branch, too
* push only newly created tag for the new release, not all local tags

This assumes that the target repository is `origin`. (Previous assumption was that the target repo for `develop` was the repo tracked by `develop` and that the target repository for the tags was `origin`.)

### Reviewed by
- [x] @hixi