### PR TITLE
make targets for easier use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,11 +142,10 @@ up_local_db:
 
 .PHONY: up_local
 up_local: up_local_db
-	${COMPOSE} up -d ${LOCAL_RUN_ONCE_SERVICES}
+	${COMPOSE} up -d ${LOCAL_APPLICATION_STACK}
 
 .PHONY: up_local_all
 up_local_all: build_local up_local_db up_local_run_once up_local
-	${COMPOSE} up -d ${LOCAL_RUN_ONCE_SERVICES}
 
 .PHONY: build_local
 build_local:

--- a/Makefile
+++ b/Makefile
@@ -125,3 +125,29 @@ down-pg_translit:
 clean: down-redis down-pg_translit down-pg
 	find . -name __pycache__ -exec rm -rf {} +
 	find . -name "*.pyc" -exec rm -rf {} +
+
+LOCAL_RUN_ONCE_SERVICES := osmboundaries_importer osm_importer
+LOCAL_DB_SERVICES := frontenddatabase mediatordatabase world-database osmboundaries-database
+LOCAL_APPLICATION_STACK := nginx frontend mediator worker worker-exclusive conversionserviceredis
+LOCAL_DEPLOY_VERSION := latest
+COMPOSE := DEPLOY_VERSION=${LOCAL_DEPLOY_VERSION} docker-compose -f docker-compose.yml -f docker-compose-dev.yml
+
+.PHONY: up_local_run_once
+up_local_run_once: up_local_db
+	${COMPOSE} up -d ${LOCAL_RUN_ONCE_SERVICES}
+
+.PHONY: up_local_db
+up_local_db:
+	${COMPOSE} up -d ${LOCAL_DB_SERVICES}
+
+.PHONY: up_local
+up_local: up_local_db
+	${COMPOSE} up -d ${LOCAL_RUN_ONCE_SERVICES}
+
+.PHONY: up_local_all
+up_local_all: build_local up_local_db up_local_run_once up_local
+	${COMPOSE} up -d ${LOCAL_RUN_ONCE_SERVICES}
+
+.PHONY: build_local
+build_local:
+	${COMPOSE} build --pull


### PR DESCRIPTION
Make it easier for new developers and returning to the project to remember the command sequence for docker-compose.

Reviewed by:
- [x] @das-g 