### PR TITLE
make static downloads visible even when not logged in

### DIFF
--- a/osmaxx/core/templates/osmaxx/navigation.html
+++ b/osmaxx/core/templates/osmaxx/navigation.html
@@ -19,12 +19,13 @@
                 <span class="menu_icon">&#x2637;</span>&nbsp;{% trans 'My Exports' %}
             </a>
         </li>
+        {% endif %}
+
         <li role="presentation">
             <a href="{% url 'pages:downloads' %}">
                 <span class="menu_icon">&#x2637;</span>&nbsp;{% trans 'Additional Downloads' %}
             </a>
         </li>
-        {% endif %}
 
         <li role="presentation">
             <a href="{% url 'pages:about' %}">


### PR DESCRIPTION
Show the additional downloads in navigation.

Reviewed by:
- [x] @das-g 

Closes #675 