### PR TITLE
#685 disallow creation of public excerpts via the frontend GUI

### DIFF
--- a/osmaxx/excerptexport/forms/excerpt_form.py
+++ b/osmaxx/excerptexport/forms/excerpt_form.py
@@ -39,7 +39,6 @@ class ExcerptForm(OrderOptionsMixin, forms.ModelForm):
                 _('Excerpt'),
                 Field('name'),
                 Field('bounding_geometry'),
-                'is_public',
             ),
             OrderOptionsMixin(self).form_layout(),
             Submit('submit', 'Submit'),
@@ -65,7 +64,7 @@ class ExcerptForm(OrderOptionsMixin, forms.ModelForm):
 
     class Meta:
         model = Excerpt
-        fields = ['name', 'is_public', 'bounding_geometry']
+        fields = ['name', 'bounding_geometry']
 
     def save(self, user):
         extraction_order = ExtractionOrder(orderer=user)
@@ -73,7 +72,7 @@ class ExcerptForm(OrderOptionsMixin, forms.ModelForm):
         extraction_order.extraction_formats = self.cleaned_data['formats']
         extraction_order.detail_level = self.cleaned_data['detail_level']
 
-        excerpt_dict = select_keys(self.cleaned_data, ['name', 'is_public', 'bounding_geometry'])
+        excerpt_dict = select_keys(self.cleaned_data, ['name', 'bounding_geometry'])
         excerpt = Excerpt(
             is_active=True,
             owner=user,

--- a/tests/excerptexport/views/test_order_excerpt_views.py
+++ b/tests/excerptexport/views/test_order_excerpt_views.py
@@ -22,7 +22,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
 
         self.new_excerpt_post_data = {
             'name': 'A very interesting region',
-            'is_public': 'True',
             'bounding_geometry': '{"type":"Polygon","coordinates":[[[8.815935552120209,47.222220486817676],[8.815935552120209,47.22402752311505],[8.818982541561127,47.22402752311505],[8.818982541561127,47.222220486817676],[8.815935552120209,47.222220486817676]]]}',
             'formats': ['fgdb'],
             'coordinate_reference_system': self.coordinate_reference_system,
@@ -125,8 +124,31 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
-            Excerpt.objects.filter(name='A very interesting region', is_active=True, is_public=True).count(),
+            Excerpt.objects.filter(name='A very interesting region', is_active=True, is_public=False).count(),
             1
+        )
+
+    @vcr.use_cassette('fixtures/vcr/views-test_create_with_new_excerpt.yml')
+    def test_create_with_new_excerpt_ignores_ispublic(self):
+        """
+        When logged in, POSTing an export request with a new excerpt is successful.
+        """
+        self.add_permissions_to_user()
+        self.client.login(username='user', password='pw')
+        self.new_excerpt_post_data['is_public'] = True
+        response = self.client.post(
+            reverse('excerptexport:order_new_excerpt'),
+            self.new_excerpt_post_data,
+            HTTP_HOST='thehost.example.com'
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            Excerpt.objects.filter(name='A very interesting region', is_active=True, is_public=False).count(),
+            1
+        )
+        self.assertEqual(
+            Excerpt.objects.filter(name='A very interesting region', is_public=True).count(),
+            0
         )
 
     @vcr.use_cassette('fixtures/vcr/views-test_create_with_existing_excerpt.yml')


### PR DESCRIPTION
closes #685

Excerpts can still be made public in the admin web interface.

### Reviewed by
- [x] @hixi