### PR TITLE
replace german part with english

### DIFF
--- a/docs/osmaxx_data_schema.md
+++ b/docs/osmaxx_data_schema.md
@@ -11,11 +11,8 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 Notes regarding limits, quality and out of scope of the data model and the related datasets.
 Goal and scope: 
 
-The OSMaxx exctracts are layed out for a broad usage. 
-Data from OSM are consolidated from OSM source where the data
-is being recorded in a consistent manner or aggregated to a degree where
-filtering and homogenising is possible without too much effort.
-This is much more than what is usually necessary to create a
+The OSMaxx exctracts are designed for broad usage.
+This goes beyond the transformations usually necessary to create a
 topoplogical map.
 
 There are known limits, omissions and bugs, which are being tracked
@@ -27,7 +24,7 @@ This document and the project just started and thus is in e pre-mature state.
 
 These are possible enhancements in next releases:
 
-* File STATISTICS.txt whith contains a report about tables, attributes and it's rows and
+* File STATISTICS.txt which contains a report about tables, attributes and it's rows and
   values.
 * Final data model (V.3?)
 * Adding attribute height to tables like poi_p from external digital terrain model data

--- a/docs/osmaxx_data_schema.md
+++ b/docs/osmaxx_data_schema.md
@@ -9,6 +9,7 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 ## Goal, scope, and limits
 
 Notes regarding limits, quality and out of scope of the data model and the related datasets.
+
 Goal and scope: 
 
 The OSMaxx exctracts are designed for broad usage.

--- a/docs/osmaxx_data_schema.md
+++ b/docs/osmaxx_data_schema.md
@@ -9,29 +9,25 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 ## Goal, scope, and limits
 
 Notes regarding limits, quality and out of scope of the data model and the related datasets.
-Goal and scope: Das OSMaxx-Datenmodell ist zur möglichst breiten Nutzung ausgelegt
-(Kartendarstellung, Orientierung, POI-Suche und räumliche Analyse und später Routing). D.h. es
-wird versucht, so viele Informationen (Tabellen, Attribute und Wertebereiche) wie möglich aus OSM
-herauszuholen, die einigermassen konsistent erfasst werden bzw. die sich filtern („Cleansing“ und
-Homogenisierung) oder aus den Daten herleiten lassen („Data Curation“). Das ist zwangsläufig
-mehr, als beispielsweise für die (gedruckte) Kartendarstellung eines topografischen
-Landschaftsmodells nötig ist.
-These are known limits, omissions and bugs:
+Goal and scope: 
 
-1. Current data export exports POLYGON instead of MULTPOLYGON
-2. Statistics is missing
-3. Missing tables: coastline_l, adminunit_a
-4. tbd.
+The OSMaxx exctracts are layed out for a broad usage. 
+Data from OSM are consolidated from OSM source where the data
+is being recorded in a consistent manner or aggregated to a degree where
+filtering and homogenising is possible without too much effort.
+This is much more than what is usually necessary to create a
+topoplogical map.
 
-Tbd.
+There are known limits, omissions and bugs, which are being tracked
+in the github-repository https://github.com/geometalab/osmaxx/issues. 
 
 ## Status of this document and future releases
 
 This document and the project just started and thus is in e pre-mature state.
 
-These are possible enhancements in next releases
+These are possible enhancements in next releases:
 
-* File STATISTICS.txt whih contains a report about tables, attributes and it's rows and
+* File STATISTICS.txt whith contains a report about tables, attributes and it's rows and
   values.
 * Final data model (V.3?)
 * Adding attribute height to tables like poi_p from external digital terrain model data

--- a/docs/osmaxx_data_schema.md
+++ b/docs/osmaxx_data_schema.md
@@ -8,10 +8,6 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 
 ## Goal, scope, and limits
 
-Notes regarding limits, quality and out of scope of the data model and the related datasets.
-
-Goal and scope: 
-
 The OSMaxx exctracts are designed for broad usage.
 This goes beyond the transformations usually necessary to create a
 topoplogical map.

--- a/docs/osmaxx_data_schema.md
+++ b/docs/osmaxx_data_schema.md
@@ -8,7 +8,7 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 
 ## Goal, scope, and limits
 
-The OSMaxx exctracts are designed for broad usage.
+The OSMaxx extracts are designed for broad usage.
 This goes beyond the transformations usually necessary to create a
 topoplogical map.
 

--- a/docs/osmaxx_data_schema.md
+++ b/docs/osmaxx_data_schema.md
@@ -13,7 +13,7 @@ This goes beyond the transformations usually necessary to create a
 topological map.
 
 There are known limits, omissions and bugs, which are being tracked
-in the github-repository https://github.com/geometalab/osmaxx/issues. 
+in the GitHub-repository https://github.com/geometalab/osmaxx/issues. 
 
 ## Status of this document and future releases
 

--- a/docs/osmaxx_data_schema.md
+++ b/docs/osmaxx_data_schema.md
@@ -10,7 +10,7 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 
 The OSMaxx extracts are designed for broad usage.
 This goes beyond the transformations usually necessary to create a
-topoplogical map.
+topological map.
 
 There are known limits, omissions and bugs, which are being tracked
 in the github-repository https://github.com/geometalab/osmaxx/issues. 

--- a/docs/schema/header.md
+++ b/docs/schema/header.md
@@ -9,29 +9,22 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 ## Goal, scope, and limits
 
 Notes regarding limits, quality and out of scope of the data model and the related datasets.
-Goal and scope: Das OSMaxx-Datenmodell ist zur möglichst breiten Nutzung ausgelegt
-(Kartendarstellung, Orientierung, POI-Suche und räumliche Analyse und später Routing). D.h. es
-wird versucht, so viele Informationen (Tabellen, Attribute und Wertebereiche) wie möglich aus OSM
-herauszuholen, die einigermassen konsistent erfasst werden bzw. die sich filtern („Cleansing“ und
-Homogenisierung) oder aus den Daten herleiten lassen („Data Curation“). Das ist zwangsläufig
-mehr, als beispielsweise für die (gedruckte) Kartendarstellung eines topografischen
-Landschaftsmodells nötig ist.
-These are known limits, omissions and bugs:
+Goal and scope: 
 
-1. Current data export exports POLYGON instead of MULTPOLYGON
-2. Statistics is missing
-3. Missing tables: coastline_l, adminunit_a
-4. tbd.
+The OSMaxx exctracts are designed for broad usage.
+This goes beyond the transformations usually necessary to create a
+topoplogical map.
 
-Tbd.
+There are known limits, omissions and bugs, which are being tracked
+in the github-repository https://github.com/geometalab/osmaxx/issues. 
 
 ## Status of this document and future releases
 
 This document and the project just started and thus is in e pre-mature state.
 
-These are possible enhancements in next releases
+These are possible enhancements in next releases:
 
-* File STATISTICS.txt whih contains a report about tables, attributes and it's rows and
+* File STATISTICS.txt which contains a report about tables, attributes and it's rows and
   values.
 * Final data model (V.3?)
 * Adding attribute height to tables like poi_p from external digital terrain model data

--- a/docs/schema/header.md
+++ b/docs/schema/header.md
@@ -9,6 +9,7 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 ## Goal, scope, and limits
 
 Notes regarding limits, quality and out of scope of the data model and the related datasets.
+
 Goal and scope: 
 
 The OSMaxx exctracts are designed for broad usage.

--- a/docs/schema/header.md
+++ b/docs/schema/header.md
@@ -8,10 +8,6 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 
 ## Goal, scope, and limits
 
-Notes regarding limits, quality and out of scope of the data model and the related datasets.
-
-Goal and scope: 
-
 The OSMaxx exctracts are designed for broad usage.
 This goes beyond the transformations usually necessary to create a
 topoplogical map.

--- a/docs/schema/header.md
+++ b/docs/schema/header.md
@@ -8,7 +8,7 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 
 ## Goal, scope, and limits
 
-The OSMaxx exctracts are designed for broad usage.
+The OSMaxx extracts are designed for broad usage.
 This goes beyond the transformations usually necessary to create a
 topoplogical map.
 

--- a/docs/schema/header.md
+++ b/docs/schema/header.md
@@ -13,7 +13,7 @@ This goes beyond the transformations usually necessary to create a
 topological map.
 
 There are known limits, omissions and bugs, which are being tracked
-in the github-repository https://github.com/geometalab/osmaxx/issues. 
+in the GitHub-repository https://github.com/geometalab/osmaxx/issues. 
 
 ## Status of this document and future releases
 

--- a/docs/schema/header.md
+++ b/docs/schema/header.md
@@ -10,7 +10,7 @@ The data referred to is from OpenStreetMap planet file licensed under ODbL 1.0.
 
 The OSMaxx extracts are designed for broad usage.
 This goes beyond the transformations usually necessary to create a
-topoplogical map.
+topological map.
 
 There are known limits, omissions and bugs, which are being tracked
 in the github-repository https://github.com/geometalab/osmaxx/issues. 


### PR DESCRIPTION
Reviewed by:

- [x] @das-g 

@das-g questions:
- we generate a very similar documentation from YML, IIRC, should this document vanish completely at some point?
- I didn't correct the mistakes in every sentence, since the table-descriptions should either be removed completely or be replaced with a link to the more up-to-date description. Which would be the best way?