### PR TITLE
Fix XSS-Protection Header sent twice

### DIFF
--- a/docker_entrypoint/nginx/default.conf.template
+++ b/docker_entrypoint/nginx/default.conf.template
@@ -23,7 +23,7 @@ add_header X-Content-Type-Options nosniff;
 # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
 # this particular website if it was disabled by the user.
 # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-add_header X-XSS-Protection "1; mode=block";
+# add_header x-xss-protection "1; mode=block";
 
 # with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
 # you can tell the browser that it can only download content from the domains you explicitly allow


### PR DESCRIPTION
this header is already set in the production nginx, this way it wil be set twice; therefore removed this line