### PR TITLE
use setting because proxy-passing headers twice does not work apparently

### DIFF
--- a/osmaxx/excerptexport/templatetags/navigation.py
+++ b/osmaxx/excerptexport/templatetags/navigation.py
@@ -1,5 +1,6 @@
 # Adopted from https://djangosnippets.org/snippets/2783/
 from django import template
+from django.conf import settings
 
 register = template.Library()
 
@@ -10,4 +11,9 @@ def siteabsoluteurl(absoluteurl, request):
     receives an argument in the form of an absolute url <absoluteurl>
     Returns the same url with all the necessary path information to be used offsite
     """
-    return request.build_absolute_uri(absoluteurl)
+    absolute_url = request.build_absolute_uri(absoluteurl)
+    if settings.OSMAXX.get('SECURED_PROXY', False) and not absolute_url.startswith('https'):
+        if absolute_url.startswith('http'):
+            absolute_url = absolute_url[4:]
+        absolute_url = 'https' + absolute_url
+    return absolute_url

--- a/web_frontend/config/settings/common.py
+++ b/web_frontend/config/settings/common.py
@@ -398,6 +398,7 @@ OSMAXX = {
     'CONVERSION_SERVICE_USERNAME': env.str('DJANGO_OSMAXX_CONVERSION_SERVICE_USERNAME', default='default_user'),
     'CONVERSION_SERVICE_PASSWORD': env.str('DJANGO_OSMAXX_CONVERSION_SERVICE_PASSWORD', default='default_password'),
     'EXCLUSIVE_USER_GROUP': 'osmaxx_high_priority',  # high priority people
+    'SECURED_PROXY': env.bool('DJANGO_OSMAXX_SECURED_PROXY', False),
 }
 
 CRISPY_TEMPLATE_PACK = 'bootstrap3'


### PR DESCRIPTION
closes #723 

Django does set [this header](https://docs.djangoproject.com/en/1.10/ref/settings/#secure-browser-xss-filter) itself with [our configuration](https://github.com/geometalab/osmaxx/blob/0d067069bb733ff32c3ab4a5eba36a059b4edb5b/docker-compose-common.yml#L7), that's the reason for the duplication.