### PR TITLE
fix #708: Encode attribute values as UTF-8 in Shapefiles, too

### DIFF
--- a/osmaxx/conversion/converters/converter_gis/extract/db_to_format/extract.py
+++ b/osmaxx/conversion/converters/converter_gis/extract/db_to_format/extract.py
@@ -18,7 +18,7 @@ FORMATS = {
     SHAPEFILE: {
         'ogr_name': 'Esri Shapefile',
         'extension': '.shp',
-        'extraction_options': [],
+        'extraction_options': ['-lco', 'ENCODING=UTF-8'],
     },
     SPATIALITE: {
         'ogr_name': 'SQLite',

--- a/osmaxx/conversion/converters/converter_gis/gis.py
+++ b/osmaxx/conversion/converters/converter_gis/gis.py
@@ -93,7 +93,6 @@ class GISConverter:
             data_location=os.path.basename(data_location),
             separator=format_definition.qgis_datasource_separator,
             extension=format_definition.layer_filename_extension,
-            attribute_value_encoding=format_definition.attribute_value_encoding,
             extent=geom_in_qgis_display_srs.extent
         ).dump(os.path.join(qgis_symbology_dir, 'OSMaxx.qgs'))
         shutil.copytree(

--- a/osmaxx/conversion/converters/converter_gis/symbology/templates/OSMaxx.qgs.jinja2
+++ b/osmaxx/conversion/converters/converter_gis/symbology/templates/OSMaxx.qgs.jinja2
@@ -456,7 +456,7 @@
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -627,7 +627,7 @@
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -896,7 +896,7 @@
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -1569,7 +1569,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -1901,7 +1901,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "fid", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -2024,7 +2024,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -2168,7 +2168,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -2423,7 +2423,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -2527,7 +2527,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -3624,7 +3624,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -4037,7 +4037,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -4226,7 +4226,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -4781,7 +4781,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -5497,7 +5497,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -6145,7 +6145,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -6493,7 +6493,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -7273,7 +7273,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -11178,7 +11178,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -11525,7 +11525,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -12277,7 +12277,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -15897,7 +15897,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -20208,7 +20208,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -20541,7 +20541,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "fid", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -20838,7 +20838,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -21173,7 +21173,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -22220,7 +22220,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -22552,7 +22552,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -22903,7 +22903,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -23663,7 +23663,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -23995,7 +23995,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -24401,7 +24401,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -25125,7 +25125,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -25570,7 +25570,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression>COALESCE( "name", '&lt;NULL>' )</previewExpression>
       <vectorjoins/>
       <layerDependencies/>
@@ -26075,7 +26075,7 @@ def my_form_open(dialog, layer, feature):
           <geographicflag>true</geographicflag>
         </spatialrefsys>
       </srs>
-      <provider encoding="{{ attribute_value_encoding }}">ogr</provider>
+      <provider encoding="UTF-8">ogr</provider>
       <previewExpression></previewExpression>
       <vectorjoins/>
       <layerDependencies/>

--- a/osmaxx/conversion_api/formats.py
+++ b/osmaxx/conversion_api/formats.py
@@ -76,7 +76,6 @@ FORMAT_DEFINITIONS = OrderedDict([
         abbreviations=[],
         is_white_box=True,
         layer_filename_extension='.shp',
-        attribute_value_encoding='ISO-8859-1',
     )),
     (GPKG, OutputFormat(
         long_identifier='GeoPackage',

--- a/osmaxx/conversion_api/formats.py
+++ b/osmaxx/conversion_api/formats.py
@@ -9,7 +9,7 @@ FGDB, SHAPEFILE, GPKG, SPATIALITE, GARMIN = 'fgdb', 'shapefile', 'gpkg', 'spatia
 class OutputFormat:
     def __init__(
             self, *, long_identifier, verbose_name, archive_file_name_identifier, abbreviations, is_white_box,
-            layer_filename_extension=None, attribute_value_encoding='UTF-8'
+            layer_filename_extension=None
     ):
         self._long_identifier = long_identifier
         self._verbose_name = verbose_name
@@ -17,7 +17,6 @@ class OutputFormat:
         self._abbreviations = abbreviations
         self._is_white_box = is_white_box
         self._layer_filename_extension = layer_filename_extension
-        self._attribute_value_encoding = attribute_value_encoding
 
     @property
     def long_identifier(self):
@@ -46,10 +45,6 @@ class OutputFormat:
         file's ``<datasource>`` element referring to data in this format.
         """
         return '/' if self._layer_filename_extension is not None else '|layername='
-
-    @property
-    def attribute_value_encoding(self):
-        return self._attribute_value_encoding
 
     def unique_archive_name(self):
         return "{}_{}.zip".format(uuid.uuid4(), self.archive_file_name_identifier)


### PR DESCRIPTION
fixes #708

Encode attribute values as UTF-8 in Shapefiles, too and let QGIS treat the values as UTF-8 encoded.
### Reviewed by
- [x] @hixi
- [ ] @sfkeller