### PR TITLE
"additional downloads" page: add link to SVG files #739

### DIFF
--- a/osmaxx/core/templates/pages/downloads.html
+++ b/osmaxx/core/templates/pages/downloads.html
@@ -22,10 +22,15 @@
             The <a href="{% static 'osmaxx/example_data/ArcGIS_styles.zip' %}">ArcGIS style</a> can be applied to any extract
             from OSMaxx. This download includes several variants of this style, each suitable for a different map scale.
         </p>
-        <h4>Symbolfont</h4>
+        <h4>Point Symbols</h4>
         <p>
             The OSMaxx point symbols as a font:
             <a href="https://github.com/geometalab/osmaxx-symbology/raw/symbolfont-1.0.0/osmaxx-symbology/OSMaxx_point_symbols/OSMaxx_v1.ttf">OSMaxx Symbolfont v1</a>
+        </p>
+        <p>
+            The individual symbols are available
+            <a href="https://github.com/geometalab/osmaxx-symbology/tree/master/osmaxx-symbology/OSMaxx_point_symbols/svg">as SVG files on GitHub</a>
+            and are also included in the download for each export.
         </p>
         <h3>OsmAnd</h3>
         <p>


### PR DESCRIPTION
"additional downloads" page: add link to SVG files of OSMaxx point symbols on GitHub

closes #739