### PR TITLE
cut pbf prior to splitting

### DIFF
--- a/tests/conversion/converters/garmin_test.py
+++ b/tests/conversion/converters/garmin_test.py
@@ -32,5 +32,5 @@ def test_create_garmin_export_calls_(output_zip_file_path, area_name, simple_osm
     subprocess_mock = mocker.patch('subprocess.check_call')
     _create_zip_mock = mocker.patch('osmaxx.conversion.converters.converter_garmin.garmin.Garmin._create_zip')
     Garmin(out_zip_file_path=output_zip_file_path, area_name=area_name, polyfile_string=simple_osmosis_line_string).create_garmin_export()
-    assert 2 == subprocess_mock.call_count
+    assert 3 == subprocess_mock.call_count  # 2 calls from garmin and one from the pbf cutter
     assert 1 == _create_zip_mock.call_count


### PR DESCRIPTION
One major reason why the pbf-splitter fails sometimes seems to be the exchange of the pbf file underneath, while the splitter is working.

This seems no problem using the osm-c-tools.

Let's use the splitter after the pbf is already cut, to avoid this problem, thus using a local temporary pbf file.