### PR TITLE
partially revert dedc688 "remove old python2 style super calls"

### DIFF
--- a/tests/excerptexport/models/test_export_model.py
+++ b/tests/excerptexport/models/test_export_model.py
@@ -11,7 +11,7 @@ from osmaxx.excerptexport._settings import EXTRACTION_PROCESSING_TIMEOUT_TIMEDEL
 @pytest.fixture
 def export_stale_status(mocker, export):
     def timestamp_model_mixin_save_side_effect(self, *args, **kwargs):
-        super().save(*args, **kwargs)
+        super(TimeStampModelMixin, self).save(*args, **kwargs)
     mocker.patch.object(TimeStampModelMixin, 'save', timestamp_model_mixin_save_side_effect)
     now = timezone.now()
     just_overdue = now - (EXTRACTION_PROCESSING_TIMEOUT_TIMEDELTA + timezone.timedelta(minutes=1))


### PR DESCRIPTION
Zero-argument `super()` cannot be used in functions defined outside the class body. See https://www.python.org/dev/peps/pep-3135/#specification

connected to #781