### PR TITLE
don't ignore *.mo files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,7 @@ nosetests.xml
 coverage.xml
 
 # Translations
-*.mo
+# *.mo  # (We DO track these, as we don't want to compile translations for every installation.)
 *.pot
 
 # Django stuff:


### PR DESCRIPTION
don't ignore `*.mo` files in Git

(we already track one, anyway)