### PR TITLE
Feature/#819 reduce frontend user group usage

### DIFF
--- a/osmaxx/contrib/auth/frontend_permissions.py
+++ b/osmaxx/contrib/auth/frontend_permissions.py
@@ -30,21 +30,6 @@ def _user_has_validated_email(user):
     return profile.has_validated_email()
 
 
-def frontend_access_required(function=None):
-    """
-    Decorator for views that checks that the user has the correct access rights,
-    redirecting to the information page if necessary.
-    """
-    profile_url = reverse_lazy('profile:edit_view')
-    actual_decorator = user_passes_test(
-        _may_user_access_osmaxx_frontend,
-        login_url=profile_url
-    )
-    if function:
-        return actual_decorator(function)
-    return actual_decorator
-
-
 def validated_email_required(function=None):
     """
     Decorator for views that checks that the user has set a validated email,
@@ -65,15 +50,6 @@ class LoginRequiredMixin(object):
     Login required Mixin for Class Based Views.
     """
     @method_decorator(login_required)
-    def dispatch(self, *args, **kwargs):
-        return super().dispatch(*args, **kwargs)
-
-
-class FrontendAccessRequiredMixin(object):
-    """
-    Frontend Access Check Mixin for Class Based Views.
-    """
-    @method_decorator(frontend_access_required)
     def dispatch(self, *args, **kwargs):
         return super().dispatch(*args, **kwargs)
 

--- a/osmaxx/contrib/auth/frontend_permissions.py
+++ b/osmaxx/contrib/auth/frontend_permissions.py
@@ -65,11 +65,11 @@ class EmailRequiredMixin(object):
 
 class AuthenticatedAndAccessPermission(permissions.BasePermission):
     """
-    Allows access only to authenticated users with frontend permissions.
+    Allows access only to authenticated users with confirmed email address.
     """
 
     def has_permission(self, request, view):
-        return request.user.is_authenticated and _may_user_access_osmaxx_frontend(request.user)
+        return request.user.is_authenticated and _user_has_validated_email(request.user)
 
 
 class HasBBoxAccessPermission(permissions.BasePermission):

--- a/osmaxx/contrib/auth/frontend_permissions.py
+++ b/osmaxx/contrib/auth/frontend_permissions.py
@@ -6,14 +6,6 @@ from rest_framework import permissions
 from osmaxx.profile.models import Profile
 
 
-def _may_user_access_osmaxx_frontend(user):
-    """
-    Actual test to check if the user is in the frontend user group,
-    to give access or deny it. Note: Admins have superpowers.
-    """
-    return user.has_perm('excerptexport.add_extractionorder')
-
-
 def _may_user_access_this_excerpt(user, excerpt):
     return excerpt.is_public or excerpt.owner == user
 

--- a/osmaxx/excerptexport/views.py
+++ b/osmaxx/excerptexport/views.py
@@ -14,7 +14,6 @@ from django.views.generic.list import ListView
 
 from osmaxx.contrib.auth.frontend_permissions import (
     LoginRequiredMixin,
-    FrontendAccessRequiredMixin,
     EmailRequiredMixin,
 )
 from osmaxx.conversion_api import statuses
@@ -47,7 +46,7 @@ class OrderFormViewMixin(FormMixin):
         )
 
 
-class AccessRestrictedBaseView(LoginRequiredMixin, FrontendAccessRequiredMixin, EmailRequiredMixin):
+class AccessRestrictedBaseView(LoginRequiredMixin, EmailRequiredMixin):
     pass
 
 

--- a/osmaxx/profile/models.py
+++ b/osmaxx/profile/models.py
@@ -14,7 +14,7 @@ class Profile(models.Model):
     unverified_email = models.EmailField(verbose_name=_('unverified email'), max_length=200, null=True)
 
     def has_validated_email(self):
-        return self.associated_user.email == self.unverified_email
+        return self.unverified_email and self.associated_user.email == self.unverified_email
 
     def activation_key(self):
         key = signing.dumps(

--- a/osmaxx/profile/views.py
+++ b/osmaxx/profile/views.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
@@ -127,21 +126,12 @@ class ActivationView(SendVerificationEmailMixin, LoginRequiredMixin, generic.Upd
             if data:
                 user.email = data['email']
                 user.save()
-                self._set_group(user)
                 messages.add_message(self.request, messages.SUCCESS, _('Successfully verified your email address.'))
             else:
                 messages.add_message(self.request, messages.ERROR, self.error_msg)
         else:
             messages.add_message(self.request, messages.ERROR, self.error_msg)
         return redirect(reverse('profile:edit_view'))
-
-    def _set_group(self, user):
-        if settings.REGISTRATION_OPEN and not user_in_frontend_group(user):
-            self._grant_user_access(user)
-
-    def _grant_user_access(self, user):
-        group = Group.objects.get(name=settings.OSMAXX_FRONTEND_USER_GROUP)
-        group.user_set.add(user)
 
 
 class ResendVerificationEmail(SendVerificationEmailMixin, LoginRequiredMixin, generic.RedirectView):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,7 +161,6 @@ def pytest_configure():
             'ACCOUNT_MANAGER_EMAIL': 'accountmanager@example.com',
         },
         OSMAXX_FRONTEND_USER_GROUP='osmaxx_frontend_users',
-        REGISTRATION_OPEN=True,
         CACHES={
             'default': {
                 'BACKEND': 'django.core.cache.backends.dummy.DummyCache',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -255,11 +255,9 @@ def authenticated_api_client(api_client, user):
 
 @pytest.fixture
 def frontend_accessible_authenticated_api_client(api_client, user):
-    from django.conf import settings
-    from django.contrib.auth.models import Group
+    from osmaxx.profile.models import Profile
 
-    group = Group.objects.get(name=settings.OSMAXX_FRONTEND_USER_GROUP)
-    user.groups.add(group)
+    Profile.objects.create(associated_user=user, unverified_email=user.email)
     return authenticated_client(api_client, user)
 
 

--- a/tests/contrib/auth/test_frontend_permissions.py
+++ b/tests/contrib/auth/test_frontend_permissions.py
@@ -1,3 +1,4 @@
+import pytest
 from django.contrib.auth.models import User
 from osmaxx.contrib.auth.frontend_permissions import _user_has_validated_email
 from osmaxx.profile.models import Profile
@@ -18,4 +19,10 @@ def test_new_superuser_has_no_validated_email_address(db):
     an_admin = User.objects.create_superuser('A. D. Min', 'admin@example.com', 'password')
     assert not _user_has_validated_email(an_admin)
 
-# TODO: neither email set -> _user_has_validated_email(...) is false
+
+@pytest.mark.parametrize('user_email', ['', None])
+@pytest.mark.parametrize('profile_email', ['', None])
+def test_user_with_empty_email_addresses(db, user_email, profile_email):
+    a_user = User.objects.create_user('U. Ser', user_email, 'password')
+    Profile.objects.create(associated_user=a_user, unverified_email=profile_email)
+    assert not _user_has_validated_email(a_user)

--- a/tests/contrib/auth/test_frontend_permissions.py
+++ b/tests/contrib/auth/test_frontend_permissions.py
@@ -1,29 +1,21 @@
-from django.conf import settings
-from django.contrib.auth.models import User, Group
-from osmaxx.contrib.auth.frontend_permissions import _may_user_access_osmaxx_frontend
+from django.contrib.auth.models import User
+from osmaxx.contrib.auth.frontend_permissions import _user_has_validated_email
+from osmaxx.profile.models import Profile
 
 
-def test_user_can_not_access_frontend_by_default(db):
-    """
-    Newly created users (self sign-up) can't do anything that non-authenticated visitors couldn't do, too, so that
-    we don't have to restrict who can sign up.
-    """
+def test_new_user_has_no_validated_email_address(db):
     a_user = User.objects.create_user('U. Ser', 'user@example.com', 'password')
-    assert not _may_user_access_osmaxx_frontend(a_user)
+    assert not _user_has_validated_email(a_user)
 
 
-def test_user_can_access_frontend_when_in_osmaxx_group(db):
-    """
-    To activate a user for frontend access, add it to the osmaxx frontend group.
-    """
+def test_user_with_same_address_on_profile_has_validated_email_address(db):
     a_user = User.objects.create_user('U. Ser', 'user@example.com', 'password')
-    a_user.groups.add(Group.objects.get(name=settings.OSMAXX_FRONTEND_USER_GROUP))
-    assert _may_user_access_osmaxx_frontend(a_user)
+    Profile.objects.create(associated_user=a_user, unverified_email=a_user.email)
+    assert _user_has_validated_email(a_user)
 
 
-def test_superuser_can_access_frontend_even_if_not_in_osmaxx_group(db):
-    """
-    Superusers cannot be created by anonymous self sign-up, so we don't require explicit group membership for them.
-    """
+def test_new_superuser_has_no_validated_email_address(db):
     an_admin = User.objects.create_superuser('A. D. Min', 'admin@example.com', 'password')
-    assert _may_user_access_osmaxx_frontend(an_admin)
+    assert not _user_has_validated_email(an_admin)
+
+# TODO: neither email set -> _user_has_validated_email(...) is false

--- a/tests/contrib/auth/test_frontend_permissions.py
+++ b/tests/contrib/auth/test_frontend_permissions.py
@@ -1,29 +1,29 @@
 from django.conf import settings
-from django.test import TestCase
 from django.contrib.auth.models import User, Group
 from osmaxx.contrib.auth.frontend_permissions import _may_user_access_osmaxx_frontend
 
 
-class TestFrontendPermissions(TestCase):
-    def test_user_can_not_access_frontend_by_default(self):
-        """
-        Newly created users (self sign-up) can't do anything that non-authenticated visitors couldn't do, too, so that
-        we don't have to restrict who can sign up.
-        """
-        a_user = User.objects.create_user('U. Ser', 'user@example.com', 'password')
-        self.assertFalse(_may_user_access_osmaxx_frontend(a_user))
+def test_user_can_not_access_frontend_by_default(db):
+    """
+    Newly created users (self sign-up) can't do anything that non-authenticated visitors couldn't do, too, so that
+    we don't have to restrict who can sign up.
+    """
+    a_user = User.objects.create_user('U. Ser', 'user@example.com', 'password')
+    assert not _may_user_access_osmaxx_frontend(a_user)
 
-    def test_user_can_access_frontend_when_in_osmaxx_group(self):
-        """
-        To activate a user for frontend access, add it to the osmaxx frontend group.
-        """
-        a_user = User.objects.create_user('U. Ser', 'user@example.com', 'password')
-        a_user.groups.add(Group.objects.get(name=settings.OSMAXX_FRONTEND_USER_GROUP))
-        self.assertTrue(_may_user_access_osmaxx_frontend(a_user))
 
-    def test_superuser_can_access_frontend_even_if_not_in_osmaxx_group(self):
-        """
-        Superusers cannot be created by anonymous self sign-up, so we don't require explicit group membership for them.
-        """
-        an_admin = User.objects.create_superuser('A. D. Min', 'admin@example.com', 'password')
-        self.assertTrue(_may_user_access_osmaxx_frontend(an_admin))
+def test_user_can_access_frontend_when_in_osmaxx_group(db):
+    """
+    To activate a user for frontend access, add it to the osmaxx frontend group.
+    """
+    a_user = User.objects.create_user('U. Ser', 'user@example.com', 'password')
+    a_user.groups.add(Group.objects.get(name=settings.OSMAXX_FRONTEND_USER_GROUP))
+    assert _may_user_access_osmaxx_frontend(a_user)
+
+
+def test_superuser_can_access_frontend_even_if_not_in_osmaxx_group(db):
+    """
+    Superusers cannot be created by anonymous self sign-up, so we don't require explicit group membership for them.
+    """
+    an_admin = User.objects.create_superuser('A. D. Min', 'admin@example.com', 'password')
+    assert _may_user_access_osmaxx_frontend(an_admin)

--- a/tests/excerptexport/permission_test_helper.py
+++ b/tests/excerptexport/permission_test_helper.py
@@ -1,16 +1,10 @@
 import pytest
-from django.conf import settings
-from django.contrib.auth.models import Group
 
 from osmaxx.profile.models import Profile
 
 
 @pytest.mark.django_db
 class PermissionHelperMixin(object):
-    def add_permissions_to_user(self):
-        group = Group.objects.get(name=settings.OSMAXX_FRONTEND_USER_GROUP)
-        self.user.groups.add(group)
-
     def add_email(self):
         self.user.email = 'test@example.com'
         self.user.save()

--- a/tests/excerptexport/views/test_export_list.py
+++ b/tests/excerptexport/views/test_export_list.py
@@ -41,15 +41,6 @@ class ExportListTestCase(TestCase, PermissionHelperMixin):
             orderer=User.objects.create_user('another_user', 'someone_else@example.com', 'top secret')
         )
 
-    def test_permission_denied_if_lacking_permissions(self, *args):
-        response = self.client.get(
-            reverse(
-                'excerptexport:export_list'
-            )
-        )
-        # redirect to 'Access Denied' page
-        self.assertEqual(response.status_code, 302)
-
     def test_permission_denied_if_lacking_email(self, *args):
         response = self.client.get(
             reverse(

--- a/tests/excerptexport/views/test_export_list.py
+++ b/tests/excerptexport/views/test_export_list.py
@@ -51,7 +51,6 @@ class ExportListTestCase(TestCase, PermissionHelperMixin):
         self.assertEqual(response.status_code, 302)
 
     def test_permission_denied_if_lacking_email(self, *args):
-        self.add_permissions_to_user()
         response = self.client.get(
             reverse(
                 'excerptexport:export_list'
@@ -61,7 +60,6 @@ class ExportListTestCase(TestCase, PermissionHelperMixin):
         self.assertEqual(response.status_code, 302)
 
     def test_access_ok_if_permissions(self, *args):
-        self.add_permissions_to_user()
         self.add_valid_email()
         response = self.client.get(
             reverse(

--- a/tests/excerptexport/views/test_order_excerpt_views.py
+++ b/tests/excerptexport/views/test_order_excerpt_views.py
@@ -67,7 +67,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         """
         When logged in, we get the excerpt choice form.
         """
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.client.login(username='user', password='pw')
         response = self.client.get(reverse('excerptexport:order_new_excerpt'))
@@ -76,7 +75,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
 
     @vcr.use_cassette('fixtures/vcr/views-test_test_new_offers_existing_own_excerpt.yml')
     def test_new_offers_existing_own_excerpt(self):
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.client.login(username='user', password='pw')
         response = self.client.get(reverse('excerptexport:order_existing_excerpt'))
@@ -88,7 +86,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
 
     @vcr.use_cassette('fixtures/vcr/views-test_test_new_offers_existing_public_foreign_excerpt.yml')
     def test_new_offers_existing_public_foreign_excerpt(self):
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.client.login(username='user', password='pw')
         response = self.client.get(reverse('excerptexport:order_existing_excerpt'))
@@ -101,7 +98,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
 
     @vcr.use_cassette('fixtures/vcr/views-test_new_doesnt_offer_existing_private_foreign_excerpt.yml')
     def test_new_doesnt_offer_existing_private_foreign_excerpt(self):
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.client.login(username='user', password='pw')
         response = self.client.get(reverse('excerptexport:order_existing_excerpt'))
@@ -119,7 +115,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         """
         When logged in, POSTing an export request with a new excerpt is successful.
         """
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.client.login(username='user', password='pw')
         response = self.client.post(
@@ -138,7 +133,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         """
         When logged in, POSTing an export request with a new excerpt is successful.
         """
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.client.login(username='user', password='pw')
         self.new_excerpt_post_data['is_public'] = True
@@ -162,7 +156,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         """
         When logged in, POSTing an export request using an existing excerpt is successful.
         """
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.client.login(username='user', password='pw')
         response = self.client.post(
@@ -180,7 +173,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         """
         When logged in, POSTing an export request with a new excerpt persists a new ExtractionOrder.
         """
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.assertEqual(ExtractionOrder.objects.count(), 0)
         self.client.login(username='user', password='pw')
@@ -200,7 +192,6 @@ class ExcerptExportViewTests(TestCase, PermissionHelperMixin):
         """
         When logged in, POSTing an export request using an existing excerpt persists a new ExtractionOrder.
         """
-        self.add_permissions_to_user()
         self.add_valid_email()
         self.assertEqual(ExtractionOrder.objects.count(), 0)
         self.client.login(username='user', password='pw')

--- a/web_frontend/config/settings/common.py
+++ b/web_frontend/config/settings/common.py
@@ -367,7 +367,6 @@ MESSAGE_STORAGE = 'stored_messages.storage.PersistentStorage'
 
 # Do not alter this once migrations have been run, since these values are stored in the database.
 OSMAXX_FRONTEND_USER_GROUP = 'osmaxx_frontend_users'
-REGISTRATION_OPEN = True  # If True, verified users are automatically being added to OSMAXX_FRONTEND_USER_GROUP
 
 # message type mapping
 MESSAGE_TAGS = {


### PR DESCRIPTION
... and don't consider `''` or `None` to be a confirmed email address. (5053c04a9f54ddee7c838be04b45a4445edbd01b)

connected to #819