### PR TITLE
Feature/refactor conversion

### DIFF
--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -35,20 +35,27 @@ class Conversion(object):
         }
         self._conversion_process = _format_process[conversion_format]
 
+        _format_converter = {
+            GARMIN: converter_garmin,
+            PBF: converter_pbf,
+            FGDB: converter_gis,
+            SHAPEFILE: converter_gis,
+            GPKG: converter_gis,
+            SPATIALITE: converter_gis,
+        }
+        self._converter = _format_converter[conversion_format]
+
     def start_format_extraction(self):
         self._conversion_process()
 
     def _extract_postgis_format(self):
-        converter = converter_gis
-        self._perform_export(converter)
+        self._perform_export(self._converter)
 
     def _create_garmin_export(self):
-        converter = converter_garmin
-        self._perform_export(converter)
+        self._perform_export(self._converter)
 
     def _create_pbf(self):
-        converter = converter_pbf
-        self._perform_export(converter)
+        self._perform_export(self._converter)
 
     def _perform_export(self, converter):
         converter.perform_export(

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -39,7 +39,8 @@ class Conversion(object):
         self._conversion_process()
 
     def _extract_postgis_format(self):
-        converter_gis.perform_export(
+        converter = converter_gis
+        converter.perform_export(
             conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,
             area_name=self._area_name,
@@ -50,7 +51,8 @@ class Conversion(object):
         )
 
     def _create_garmin_export(self):
-        converter_garmin.perform_export(
+        converter = converter_garmin
+        converter.perform_export(
             conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,
             area_name=self._area_name,
@@ -61,7 +63,8 @@ class Conversion(object):
         )
 
     def _create_pbf(self):
-        converter_pbf.perform_export(
+        converter = converter_pbf
+        converter.perform_export(
             conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,
             area_name=self._area_name,

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -42,6 +42,7 @@ class Conversion(object):
         converter_gis.perform_export(
             conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,
+            area_name=self._area_name,
             filename_prefix=self._name_prefix,
             out_srs=self._out_srs,
             polyfile_string=self._polyfile_string,
@@ -50,16 +51,24 @@ class Conversion(object):
 
     def _create_garmin_export(self):
         converter_garmin.perform_export(
+            conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,
             area_name=self._area_name,
+            filename_prefix=self._name_prefix,
+            out_srs=self._out_srs,
             polyfile_string=self._polyfile_string,
+            detail_level=self._detail_level,
         )
 
     def _create_pbf(self):
         converter_pbf.perform_export(
+            conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,
+            area_name=self._area_name,
             filename_prefix=self._name_prefix,
+            out_srs=self._out_srs,
             polyfile_string=self._polyfile_string,
+            detail_level=self._detail_level,
         )
 
 

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -1,6 +1,6 @@
-from osmaxx.conversion.converters.converter_garmin.garmin import Garmin
-from osmaxx.conversion.converters.converter_gis.gis import GISConverter
-from osmaxx.conversion.converters.converter_pbf.to_pbf import produce_pbf
+from osmaxx.conversion.converters import converter_garmin
+from osmaxx.conversion.converters import converter_gis
+from osmaxx.conversion.converters import converter_pbf
 from osmaxx.conversion.job_dispatcher.rq_dispatcher import rq_enqueue_with_settings
 from osmaxx.conversion_api.formats import FGDB, SHAPEFILE, GPKG, SPATIALITE, GARMIN, PBF
 
@@ -39,27 +39,25 @@ class Conversion(object):
         self._conversion_process()
 
     def _extract_postgis_format(self):
-        gis = GISConverter(
+        converter_gis.perform_export(
             conversion_format=self._conversion_format,
-            out_zip_file_path=self._output_zip_file_path,
-            base_file_name=self._name_prefix,
+            output_zip_file_path=self._output_zip_file_path,
+            filename_prefix=self._name_prefix,
             out_srs=self._out_srs,
             polyfile_string=self._polyfile_string,
-            detail_level=self._detail_level
+            detail_level=self._detail_level,
         )
-        gis.create_gis_export()
 
     def _create_garmin_export(self):
-        garmin = Garmin(
-            out_zip_file_path=self._output_zip_file_path,
+        converter_garmin.perform_export(
+            output_zip_file_path=self._output_zip_file_path,
             area_name=self._area_name,
             polyfile_string=self._polyfile_string,
         )
-        garmin.create_garmin_export()
 
     def _create_pbf(self):
-        produce_pbf(
-            out_zip_file_path=self._output_zip_file_path,
+        converter_pbf.perform_export(
+            output_zip_file_path=self._output_zip_file_path,
             filename_prefix=self._name_prefix,
             polyfile_string=self._polyfile_string,
         )

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -25,16 +25,6 @@ class Conversion(object):
         self._out_srs = out_srs
         self._detail_level = detail_level
 
-        _format_process = {
-            GARMIN: self._create_garmin_export,
-            PBF: self._create_pbf,
-            FGDB: self._extract_postgis_format,
-            SHAPEFILE: self._extract_postgis_format,
-            GPKG: self._extract_postgis_format,
-            SPATIALITE: self._extract_postgis_format,
-        }
-        self._conversion_process = _format_process[conversion_format]
-
         _format_converter = {
             GARMIN: converter_garmin,
             PBF: converter_pbf,
@@ -46,15 +36,6 @@ class Conversion(object):
         self._converter = _format_converter[conversion_format]
 
     def start_format_extraction(self):
-        self._conversion_process()
-
-    def _extract_postgis_format(self):
-        self._perform_export(self._converter)
-
-    def _create_garmin_export(self):
-        self._perform_export(self._converter)
-
-    def _create_pbf(self):
         self._perform_export(self._converter)
 
     def _perform_export(self, converter):

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -36,10 +36,7 @@ class Conversion(object):
         self._converter = _format_converter[conversion_format]
 
     def start_format_extraction(self):
-        self._perform_export(self._converter)
-
-    def _perform_export(self, converter):
-        converter.perform_export(
+        self._converter.perform_export(
             conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,
             area_name=self._area_name,

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -3,6 +3,18 @@ from osmaxx.conversion.converters import converter_gis
 from osmaxx.conversion.converters import converter_pbf
 from osmaxx.conversion.job_dispatcher.rq_dispatcher import rq_enqueue_with_settings
 from osmaxx.conversion_api.formats import FGDB, SHAPEFILE, GPKG, SPATIALITE, GARMIN, PBF
+from osmaxx.utils.frozendict import frozendict
+
+_format_converter = frozendict(
+    {
+        GARMIN: converter_garmin,
+        PBF: converter_pbf,
+        FGDB: converter_gis,
+        SHAPEFILE: converter_gis,
+        GPKG: converter_gis,
+        SPATIALITE: converter_gis,
+    }
+)
 
 
 class Conversion(object):
@@ -24,15 +36,6 @@ class Conversion(object):
         self._name_prefix = filename_prefix
         self._out_srs = out_srs
         self._detail_level = detail_level
-
-        _format_converter = {
-            GARMIN: converter_garmin,
-            PBF: converter_pbf,
-            FGDB: converter_gis,
-            SHAPEFILE: converter_gis,
-            GPKG: converter_gis,
-            SPATIALITE: converter_gis,
-        }
         self._converter = _format_converter[conversion_format]
 
     def start_format_extraction(self):

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -34,7 +34,7 @@ def start_format_extraction(
         area_name=area_name,
         filename_prefix=filename_prefix,
         out_srs=out_srs,
-        polyfile_string=osmosis_polygon_file_string,
+        osmosis_polygon_file_string=osmosis_polygon_file_string,
         detail_level=detail_level,
     )
 

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -40,30 +40,17 @@ class Conversion(object):
 
     def _extract_postgis_format(self):
         converter = converter_gis
-        converter.perform_export(
-            conversion_format=self._conversion_format,
-            output_zip_file_path=self._output_zip_file_path,
-            area_name=self._area_name,
-            filename_prefix=self._name_prefix,
-            out_srs=self._out_srs,
-            polyfile_string=self._polyfile_string,
-            detail_level=self._detail_level,
-        )
+        self._perform_export(converter)
 
     def _create_garmin_export(self):
         converter = converter_garmin
-        converter.perform_export(
-            conversion_format=self._conversion_format,
-            output_zip_file_path=self._output_zip_file_path,
-            area_name=self._area_name,
-            filename_prefix=self._name_prefix,
-            out_srs=self._out_srs,
-            polyfile_string=self._polyfile_string,
-            detail_level=self._detail_level,
-        )
+        self._perform_export(converter)
 
     def _create_pbf(self):
         converter = converter_pbf
+        self._perform_export(converter)
+
+    def _perform_export(self, converter):
         converter.perform_export(
             conversion_format=self._conversion_format,
             output_zip_file_path=self._output_zip_file_path,

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -17,28 +17,6 @@ _format_converter = frozendict(
 )
 
 
-def start_format_extraction(
-        *,
-        conversion_format,
-        area_name,
-        osmosis_polygon_file_string,
-        output_zip_file_path,
-        filename_prefix,
-        detail_level,
-        out_srs
-):
-    converter = _format_converter[conversion_format]
-    converter.perform_export(
-        conversion_format=conversion_format,
-        output_zip_file_path=output_zip_file_path,
-        area_name=area_name,
-        filename_prefix=filename_prefix,
-        out_srs=out_srs,
-        osmosis_polygon_file_string=osmosis_polygon_file_string,
-        detail_level=detail_level,
-    )
-
-
 def convert(
         *, conversion_format, area_name, osmosis_polygon_file_string, output_zip_file_path, filename_prefix,
         out_srs, detail_level, use_worker=False, queue_name='default'
@@ -61,5 +39,6 @@ def convert(
             queue_name=queue_name,
             **params
         ).id
-    start_format_extraction(**params)
+    converter = _format_converter[conversion_format]
+    converter.perform_export(**params)
     return None

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -17,37 +17,26 @@ _format_converter = frozendict(
 )
 
 
-class Conversion(object):
-    def __init__(
-            self,
-            *,
-            conversion_format,
-            area_name,
-            osmosis_polygon_file_string,
-            output_zip_file_path,
-            filename_prefix,
-            detail_level,
-            out_srs=None
-    ):
-        self._conversion_format = conversion_format
-        self._output_zip_file_path = output_zip_file_path
-        self._area_name = area_name
-        self._polyfile_string = osmosis_polygon_file_string
-        self._name_prefix = filename_prefix
-        self._out_srs = out_srs
-        self._detail_level = detail_level
-        self._converter = _format_converter[conversion_format]
-
-    def start_format_extraction(self):
-        self._converter.perform_export(
-            conversion_format=self._conversion_format,
-            output_zip_file_path=self._output_zip_file_path,
-            area_name=self._area_name,
-            filename_prefix=self._name_prefix,
-            out_srs=self._out_srs,
-            polyfile_string=self._polyfile_string,
-            detail_level=self._detail_level,
-        )
+def start_format_extraction(
+        *,
+        conversion_format,
+        area_name,
+        osmosis_polygon_file_string,
+        output_zip_file_path,
+        filename_prefix,
+        detail_level,
+        out_srs=None
+):
+    converter = _format_converter[conversion_format]
+    converter.perform_export(
+        conversion_format=conversion_format,
+        output_zip_file_path=output_zip_file_path,
+        area_name=area_name,
+        filename_prefix=filename_prefix,
+        out_srs=out_srs,
+        polyfile_string=osmosis_polygon_file_string,
+        detail_level=detail_level,
+    )
 
 
 def convert(
@@ -72,6 +61,5 @@ def convert(
             queue_name=queue_name,
             **params
         ).id
-    conversion = Conversion(**params)
-    conversion.start_format_extraction()
+    start_format_extraction(**params)
     return None

--- a/osmaxx/conversion/converters/converter.py
+++ b/osmaxx/conversion/converters/converter.py
@@ -25,7 +25,7 @@ def start_format_extraction(
         output_zip_file_path,
         filename_prefix,
         detail_level,
-        out_srs=None
+        out_srs
 ):
     converter = _format_converter[conversion_format]
     converter.perform_export(

--- a/osmaxx/conversion/converters/converter_garmin/__init__.py
+++ b/osmaxx/conversion/converters/converter_garmin/__init__.py
@@ -1,0 +1,3 @@
+from .garmin import perform_export
+
+__all__ = ['perform_export']

--- a/osmaxx/conversion/converters/converter_garmin/garmin.py
+++ b/osmaxx/conversion/converters/converter_garmin/garmin.py
@@ -10,6 +10,16 @@ from osmaxx.conversion.converters.converter_pbf.to_pbf import cut_pbf_along_poly
 
 from osmaxx.conversion.converters.utils import zip_folders_relative, recursive_getsize, logged_check_call
 
+
+def perform_export(*, output_zip_file_path, area_name, polyfile_string):
+    garmin = Garmin(
+        output_zip_file_path=output_zip_file_path,
+        area_name=area_name,
+        polyfile_string=polyfile_string,
+    )
+    garmin.create_garmin_export()
+
+
 _path_to_commandline_utils = os.path.join(os.path.dirname(__file__), 'command_line_utils')
 _path_to_bounds_zip = os.path.join(CONVERSION_SETTINGS['SEA_AND_BOUNDS_ZIP_DIRECTORY'], 'bounds.zip')
 _path_to_sea_zip = os.path.join(CONVERSION_SETTINGS['SEA_AND_BOUNDS_ZIP_DIRECTORY'], 'sea.zip')
@@ -17,8 +27,8 @@ _path_to_geonames_zip = os.path.join(os.path.dirname(__file__), 'additional_data
 
 
 class Garmin:
-    def __init__(self, *, out_zip_file_path, area_name, polyfile_string):
-        self._resulting_zip_file_path = out_zip_file_path
+    def __init__(self, *, output_zip_file_path, area_name, polyfile_string):
+        self._resulting_zip_file_path = output_zip_file_path
         self._map_description = area_name
         self._osmosis_polygon_file = tempfile.NamedTemporaryFile(suffix='.poly', mode='w')
         self._osmosis_polygon_file.write(polyfile_string)

--- a/osmaxx/conversion/converters/converter_garmin/garmin.py
+++ b/osmaxx/conversion/converters/converter_garmin/garmin.py
@@ -11,11 +11,11 @@ from osmaxx.conversion.converters.converter_pbf.to_pbf import cut_pbf_along_poly
 from osmaxx.conversion.converters.utils import zip_folders_relative, recursive_getsize, logged_check_call
 
 
-def perform_export(*, output_zip_file_path, area_name, polyfile_string, **__):
+def perform_export(*, output_zip_file_path, area_name, osmosis_polygon_file_string, **__):
     garmin = Garmin(
         output_zip_file_path=output_zip_file_path,
         area_name=area_name,
-        polyfile_string=polyfile_string,
+        polyfile_string=osmosis_polygon_file_string,
     )
     garmin.create_garmin_export()
 

--- a/osmaxx/conversion/converters/converter_garmin/garmin.py
+++ b/osmaxx/conversion/converters/converter_garmin/garmin.py
@@ -11,7 +11,7 @@ from osmaxx.conversion.converters.converter_pbf.to_pbf import cut_pbf_along_poly
 from osmaxx.conversion.converters.utils import zip_folders_relative, recursive_getsize, logged_check_call
 
 
-def perform_export(*, output_zip_file_path, area_name, polyfile_string):
+def perform_export(*, output_zip_file_path, area_name, polyfile_string, **__):
     garmin = Garmin(
         output_zip_file_path=output_zip_file_path,
         area_name=area_name,

--- a/osmaxx/conversion/converters/converter_gis/__init__.py
+++ b/osmaxx/conversion/converters/converter_gis/__init__.py
@@ -1,0 +1,3 @@
+from .gis import perform_export
+
+__all__ = ['perform_export']

--- a/osmaxx/conversion/converters/converter_gis/gis.py
+++ b/osmaxx/conversion/converters/converter_gis/gis.py
@@ -18,7 +18,7 @@ from osmaxx.conversion.converters.utils import zip_folders_relative, recursive_g
 from osmaxx.conversion_api.formats import FORMAT_DEFINITIONS
 
 
-def perform_export(*, conversion_format, output_zip_file_path, filename_prefix, out_srs, polyfile_string, detail_level):
+def perform_export(*, conversion_format, output_zip_file_path, filename_prefix, out_srs, polyfile_string, detail_level, **__):
     gis = GISConverter(
         conversion_format=conversion_format,
         output_zip_file_path=output_zip_file_path,

--- a/osmaxx/conversion/converters/converter_gis/gis.py
+++ b/osmaxx/conversion/converters/converter_gis/gis.py
@@ -19,13 +19,14 @@ from osmaxx.conversion_api.formats import FORMAT_DEFINITIONS
 
 
 def perform_export(
-        *, conversion_format, output_zip_file_path, filename_prefix, out_srs, polyfile_string, detail_level, **__):
+        *, conversion_format, output_zip_file_path, filename_prefix, out_srs, osmosis_polygon_file_string, detail_level,
+        **__):
     gis = GISConverter(
         conversion_format=conversion_format,
         output_zip_file_path=output_zip_file_path,
         base_file_name=filename_prefix,
         out_srs=out_srs,
-        polyfile_string=polyfile_string,
+        polyfile_string=osmosis_polygon_file_string,
         detail_level=detail_level
     )
     gis.create_gis_export()

--- a/osmaxx/conversion/converters/converter_gis/gis.py
+++ b/osmaxx/conversion/converters/converter_gis/gis.py
@@ -18,6 +18,18 @@ from osmaxx.conversion.converters.utils import zip_folders_relative, recursive_g
 from osmaxx.conversion_api.formats import FORMAT_DEFINITIONS
 
 
+def perform_export(*, conversion_format, output_zip_file_path, filename_prefix, out_srs, polyfile_string, detail_level):
+    gis = GISConverter(
+        conversion_format=conversion_format,
+        output_zip_file_path=output_zip_file_path,
+        base_file_name=filename_prefix,
+        out_srs=out_srs,
+        polyfile_string=polyfile_string,
+        detail_level=detail_level
+    )
+    gis.create_gis_export()
+
+
 QGIS_DISPLAY_SRID = 3857  # Web Mercator
 
 
@@ -28,12 +40,12 @@ class ScaleLevel(Enum):
 
 
 class GISConverter:
-    def __init__(self, *, conversion_format, out_zip_file_path, base_file_name, out_srs, polyfile_string, detail_level):
+    def __init__(self, *, conversion_format, output_zip_file_path, base_file_name, out_srs, polyfile_string, detail_level):
         """
         Converts a specified pbf into the specified format.
 
         Args:
-            out_zip_file_path: path to where the zipped result should be stored, directory must already exist
+            output_zip_file_path: path to where the zipped result should be stored, directory must already exist
             conversion_format: One of 'fgdb', 'shapefile', 'gpkg', 'spatialite'
             base_file_name: base for created files inside the zip file
 
@@ -41,7 +53,7 @@ class GISConverter:
             the path to the resulting zip file
         """
         self._base_file_name = base_file_name
-        self._out_zip_file_path = out_zip_file_path
+        self._out_zip_file_path = output_zip_file_path
         self._polyfile_string = polyfile_string
         self._conversion_format = conversion_format
         self._out_srs = out_srs

--- a/osmaxx/conversion/converters/converter_gis/gis.py
+++ b/osmaxx/conversion/converters/converter_gis/gis.py
@@ -18,7 +18,8 @@ from osmaxx.conversion.converters.utils import zip_folders_relative, recursive_g
 from osmaxx.conversion_api.formats import FORMAT_DEFINITIONS
 
 
-def perform_export(*, conversion_format, output_zip_file_path, filename_prefix, out_srs, polyfile_string, detail_level, **__):
+def perform_export(
+        *, conversion_format, output_zip_file_path, filename_prefix, out_srs, polyfile_string, detail_level, **__):
     gis = GISConverter(
         conversion_format=conversion_format,
         output_zip_file_path=output_zip_file_path,
@@ -40,7 +41,8 @@ class ScaleLevel(Enum):
 
 
 class GISConverter:
-    def __init__(self, *, conversion_format, output_zip_file_path, base_file_name, out_srs, polyfile_string, detail_level):
+    def __init__(
+            self, *, conversion_format, output_zip_file_path, base_file_name, out_srs, polyfile_string, detail_level):
         """
         Converts a specified pbf into the specified format.
 

--- a/osmaxx/conversion/converters/converter_pbf/__init__.py
+++ b/osmaxx/conversion/converters/converter_pbf/__init__.py
@@ -1,0 +1,3 @@
+from .to_pbf import produce_pbf as perform_export
+
+__all__ = ['perform_export']

--- a/osmaxx/conversion/converters/converter_pbf/to_pbf.py
+++ b/osmaxx/conversion/converters/converter_pbf/to_pbf.py
@@ -31,7 +31,7 @@ def cut_pbf_along_polyfile(polyfile_string, pbf_out_path):
         cut_area_from_pbf(pbf_out_path, polyfile.name)
 
 
-def produce_pbf(*, out_zip_file_path, filename_prefix, polyfile_string):
+def produce_pbf(*, output_zip_file_path, filename_prefix, polyfile_string):
     _start_time = timezone.now()
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -45,7 +45,7 @@ def produce_pbf(*, out_zip_file_path, filename_prefix, polyfile_string):
 
         unzipped_result_size = recursive_getsize(out_dir)
 
-        zip_folders_relative([tmp_dir], out_zip_file_path)
+        zip_folders_relative([tmp_dir], output_zip_file_path)
 
     job = get_current_job()
     if job:

--- a/osmaxx/conversion/converters/converter_pbf/to_pbf.py
+++ b/osmaxx/conversion/converters/converter_pbf/to_pbf.py
@@ -31,7 +31,7 @@ def cut_pbf_along_polyfile(polyfile_string, pbf_out_path):
         cut_area_from_pbf(pbf_out_path, polyfile.name)
 
 
-def produce_pbf(*, output_zip_file_path, filename_prefix, polyfile_string):
+def produce_pbf(*, output_zip_file_path, filename_prefix, polyfile_string, **__):
     _start_time = timezone.now()
 
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/osmaxx/conversion/converters/converter_pbf/to_pbf.py
+++ b/osmaxx/conversion/converters/converter_pbf/to_pbf.py
@@ -31,7 +31,7 @@ def cut_pbf_along_polyfile(polyfile_string, pbf_out_path):
         cut_area_from_pbf(pbf_out_path, polyfile.name)
 
 
-def produce_pbf(*, output_zip_file_path, filename_prefix, polyfile_string, **__):
+def produce_pbf(*, output_zip_file_path, filename_prefix, osmosis_polygon_file_string, **__):
     _start_time = timezone.now()
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -41,7 +41,7 @@ def produce_pbf(*, output_zip_file_path, filename_prefix, polyfile_string, **__)
 
         shutil.copy(odb_license, out_dir)
 
-        cut_pbf_along_polyfile(polyfile_string, pbf_out_path)
+        cut_pbf_along_polyfile(osmosis_polygon_file_string, pbf_out_path)
 
         unzipped_result_size = recursive_getsize(out_dir)
 

--- a/tests/conversion/converters/converter_test.py
+++ b/tests/conversion/converters/converter_test.py
@@ -1,11 +1,11 @@
-from osmaxx.conversion.converters.converter import Conversion, convert
+from osmaxx.conversion.converters.converter import start_format_extraction, convert
 
 
 def test_start_format_extraction(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
     gis_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_gis.perform_export', autospec=True)
     garmin_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_garmin.perform_export', autospec=True)
     pbf_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter.converter_pbf.perform_export', autospec=True)
-    conversion = Conversion(
+    start_format_extraction(
         conversion_format=conversion_format,
         area_name=area_name,
         osmosis_polygon_file_string=simple_osmosis_line_string,
@@ -14,7 +14,6 @@ def test_start_format_extraction(conversion_format, area_name, simple_osmosis_li
         detail_level=detail_level,
         out_srs='EPSG:{}'.format(out_srs),
     )
-    conversion.start_format_extraction()
     assert gis_converter_mock_create.call_count + garmin_converter_mock_create.call_count + pbf_converter_mock_create.call_count == 1
 
 
@@ -35,7 +34,7 @@ def test_convert_returns_id_when_use_worker_is_true(conversion_format, area_name
 
 
 def test_convert_starts_conversion(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker, monkeypatch):
-    conversion_start_start_format_extraction_mock = mocker.patch('osmaxx.conversion.converters.converter.Conversion')
+    conversion_start_start_format_extraction_mock = mocker.patch('osmaxx.conversion.converters.converter.start_format_extraction')
     convert_return_value = convert(
         conversion_format=conversion_format,
         area_name=area_name,

--- a/tests/conversion/converters/converter_test.py
+++ b/tests/conversion/converters/converter_test.py
@@ -1,11 +1,11 @@
-from osmaxx.conversion.converters.converter import start_format_extraction, convert
+from osmaxx.conversion.converters.converter import convert
 
 
-def test_start_format_extraction(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
+def test_calls_converter_and_returns_none_when_use_worker_is_omitted(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
     gis_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_gis.perform_export', autospec=True)
     garmin_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_garmin.perform_export', autospec=True)
     pbf_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter.converter_pbf.perform_export', autospec=True)
-    start_format_extraction(
+    convert_return_value = convert(
         conversion_format=conversion_format,
         area_name=area_name,
         osmosis_polygon_file_string=simple_osmosis_line_string,
@@ -15,6 +15,7 @@ def test_start_format_extraction(conversion_format, area_name, simple_osmosis_li
         out_srs='EPSG:{}'.format(out_srs),
     )
     assert gis_converter_mock_create.call_count + garmin_converter_mock_create.call_count + pbf_converter_mock_create.call_count == 1
+    assert convert_return_value is None
 
 
 def test_convert_returns_id_when_use_worker_is_true(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, rq_mock_return, mocker, monkeypatch):
@@ -31,19 +32,3 @@ def test_convert_returns_id_when_use_worker_is_true(conversion_format, area_name
         use_worker=True,
     )
     assert convert_return_value == 42
-
-
-def test_convert_starts_conversion(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
-    conversion_start_start_format_extraction_mock = mocker.patch('osmaxx.conversion.converters.converter.start_format_extraction')
-    convert_return_value = convert(
-        conversion_format=conversion_format,
-        area_name=area_name,
-        osmosis_polygon_file_string=simple_osmosis_line_string,
-        output_zip_file_path=output_zip_file_path,
-        filename_prefix=filename_prefix,
-        detail_level=detail_level,
-        out_srs='EPSG:{}'.format(out_srs),
-        use_worker=False,
-    )
-    assert convert_return_value is None
-    assert conversion_start_start_format_extraction_mock.call_count == 1

--- a/tests/conversion/converters/converter_test.py
+++ b/tests/conversion/converters/converter_test.py
@@ -2,9 +2,9 @@ from osmaxx.conversion.converters.converter import Conversion, convert
 
 
 def test_start_format_extraction(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
-    gis_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_gis.perform_export')
-    garmin_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_garmin.perform_export')
-    pbf_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter.converter_pbf.perform_export')
+    gis_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_gis.perform_export', autospec=True)
+    garmin_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_garmin.perform_export', autospec=True)
+    pbf_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter.converter_pbf.perform_export', autospec=True)
     conversion = Conversion(
         conversion_format=conversion_format,
         area_name=area_name,

--- a/tests/conversion/converters/converter_test.py
+++ b/tests/conversion/converters/converter_test.py
@@ -4,7 +4,7 @@ from osmaxx.conversion.converters.converter import Conversion, convert
 def test_start_format_extraction(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
     gis_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_gis.gis.GISConverter.create_gis_export')
     garmin_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_garmin.garmin.Garmin.create_garmin_export')
-    pbf_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter.produce_pbf')
+    pbf_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter.converter_pbf.perform_export')
     conversion = Conversion(
         conversion_format=conversion_format,
         area_name=area_name,

--- a/tests/conversion/converters/converter_test.py
+++ b/tests/conversion/converters/converter_test.py
@@ -2,8 +2,8 @@ from osmaxx.conversion.converters.converter import Conversion, convert
 
 
 def test_start_format_extraction(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
-    gis_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_gis.gis.GISConverter.create_gis_export')
-    garmin_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_garmin.garmin.Garmin.create_garmin_export')
+    gis_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_gis.perform_export')
+    garmin_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter_garmin.perform_export')
     pbf_converter_mock_create = mocker.patch('osmaxx.conversion.converters.converter.converter_pbf.perform_export')
     conversion = Conversion(
         conversion_format=conversion_format,

--- a/tests/conversion/converters/converter_test.py
+++ b/tests/conversion/converters/converter_test.py
@@ -33,7 +33,7 @@ def test_convert_returns_id_when_use_worker_is_true(conversion_format, area_name
     assert convert_return_value == 42
 
 
-def test_convert_starts_conversion(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker, monkeypatch):
+def test_convert_starts_conversion(conversion_format, area_name, simple_osmosis_line_string, output_zip_file_path, filename_prefix, detail_level, out_srs, mocker):
     conversion_start_start_format_extraction_mock = mocker.patch('osmaxx.conversion.converters.converter.start_format_extraction')
     convert_return_value = convert(
         conversion_format=conversion_format,

--- a/tests/conversion/converters/garmin_test.py
+++ b/tests/conversion/converters/garmin_test.py
@@ -31,6 +31,6 @@ def test_libraries_are_contained_in_source(library_path):
 def test_create_garmin_export_calls_(output_zip_file_path, area_name, simple_osmosis_line_string, mocker):
     subprocess_mock = mocker.patch('subprocess.check_call')
     _create_zip_mock = mocker.patch('osmaxx.conversion.converters.converter_garmin.garmin.Garmin._create_zip')
-    Garmin(out_zip_file_path=output_zip_file_path, area_name=area_name, polyfile_string=simple_osmosis_line_string).create_garmin_export()
+    Garmin(output_zip_file_path=output_zip_file_path, area_name=area_name, polyfile_string=simple_osmosis_line_string).create_garmin_export()
     assert 3 == subprocess_mock.call_count  # 2 calls from garmin and one from the pbf cutter
     assert 1 == _create_zip_mock.call_count


### PR DESCRIPTION
Simplifying stuff a bit by using an implicit interface for the format-specific conversion packages: They now must provide a `perform_export` function taking the argument they need as keyword arguments + accepting arbitrary additional keyword arguments.

Note that, if I'm not mistaken, all these changes are `worker`-side, thus this should be a non-breaking change, as the contract for the queue content should remain the same. As always, a deployment of all containers is recommended anyways when this change is released.

This refactoring adds a bit boilerplate code to the individual format-specific conversion modules. This was done to keep this refactoring as localized as possible and that redundancy might be removed again in further refactorings.