### PR TITLE
refactoring: use Django's LoginRequiredMixin

### DIFF
--- a/osmaxx/contrib/auth/frontend_permissions.py
+++ b/osmaxx/contrib/auth/frontend_permissions.py
@@ -1,4 +1,4 @@
-from django.contrib.auth.decorators import login_required, user_passes_test
+from django.contrib.auth.decorators import user_passes_test
 from django.core.urlresolvers import reverse_lazy
 from django.utils.decorators import method_decorator
 from rest_framework import permissions
@@ -35,15 +35,6 @@ def validated_email_required(function=None):
     if function:
         return actual_decorator(function)
     return actual_decorator
-
-
-class LoginRequiredMixin(object):
-    """
-    Login required Mixin for Class Based Views.
-    """
-    @method_decorator(login_required)
-    def dispatch(self, *args, **kwargs):
-        return super().dispatch(*args, **kwargs)
 
 
 class EmailRequiredMixin(object):

--- a/osmaxx/excerptexport/views.py
+++ b/osmaxx/excerptexport/views.py
@@ -13,9 +13,7 @@ from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.edit import FormMixin, DeleteView
 from django.views.generic.list import ListView
 
-from osmaxx.contrib.auth.frontend_permissions import (
-    EmailRequiredMixin,
-)
+from osmaxx.contrib.auth.frontend_permissions import EmailRequiredMixin
 from osmaxx.conversion_api import statuses
 from osmaxx.excerptexport.forms import ExcerptForm, ExistingForm
 from osmaxx.excerptexport.models import Excerpt

--- a/osmaxx/excerptexport/views.py
+++ b/osmaxx/excerptexport/views.py
@@ -2,6 +2,7 @@ import logging
 from collections import OrderedDict
 
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
@@ -13,7 +14,6 @@ from django.views.generic.edit import FormMixin, DeleteView
 from django.views.generic.list import ListView
 
 from osmaxx.contrib.auth.frontend_permissions import (
-    LoginRequiredMixin,
     EmailRequiredMixin,
 )
 from osmaxx.conversion_api import statuses

--- a/osmaxx/profile/views.py
+++ b/osmaxx/profile/views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.cache import cache
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
@@ -10,7 +11,6 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from django.views import generic
 
-from osmaxx.contrib.auth.frontend_permissions import LoginRequiredMixin
 from osmaxx.profile.forms import ProfileForm
 from osmaxx.profile.models import Profile
 


### PR DESCRIPTION
use [Django's LoginRequiredMixin](https://docs.djangoproject.com/en/1.10/topics/auth/default/#the-loginrequired-mixin) (available since Django 1.9) instead of maintaining our own implementation of that