### PR TITLE
#780 return user to original page after login

### DIFF
--- a/osmaxx/core/templates/osmaxx/login.html
+++ b/osmaxx/core/templates/osmaxx/login.html
@@ -22,6 +22,6 @@
             {% endblocktrans %}
         </p>
 
-        <a style="font-size: 1.2em;" class="btn btn-default btn-success" href="{% url 'social:begin' 'openstreetmap' %}"><img src="{% static 'images/profile/osm_logo.svg' %}" alt="OSM Logo" height="32" width="32" />&nbsp;<strong>Log in</strong> using OpenStreetMap</a>
+        <a style="font-size: 1.2em;" class="btn btn-default btn-success" href="{% url 'social:begin' 'openstreetmap' %}?next={{ request.GET.next }}"><img src="{% static 'images/profile/osm_logo.svg' %}" alt="OSM Logo" height="32" width="32" />&nbsp;<strong>Log in</strong> using OpenStreetMap</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
connected to #780 (part of it, actually)

This redirects the user to the page from where they came to our `/login` page, after they've logged in using an external identity/authentication provider (currently OpenStreetMap).

With the help of [the documentation](http://python-social-auth.readthedocs.io/en/latest/use_cases.html#return-the-user-to-the-original-page) this was surprisingly easy. Everything else was already in place. (The `next=` parameter when being redirected to our `/login` page is set by the `django.contrib.auth` machinery triggered by `LoginRequiredMixin`. The `@login_required` decorator on a function-style view would trigger a different mechanism to cause the same effect.)