### PR TITLE
Feature/move _send_email_verification to models.profile

### DIFF
--- a/osmaxx/profile/email_confirmation.py
+++ b/osmaxx/profile/email_confirmation.py
@@ -7,13 +7,15 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 
+RATE_LIMIT_SECONDS = 30
 
-def _send_email_verification(rate_limit_seconds, request, profile):
+
+def _send_email_verification(request, profile):
     if cache.get(profile.associated_user.id):
         return
     to_email = profile.unverified_email
     if to_email:
-        cache.set(profile.associated_user.id, 'dummy value', timeout=rate_limit_seconds)
+        cache.set(profile.associated_user.id, 'dummy value', timeout=RATE_LIMIT_SECONDS)
         user_administrator_email = settings.OSMAXX['ACCOUNT_MANAGER_EMAIL']
         token = profile.activation_key()
         token_url = '{}?token={}'.format(

--- a/osmaxx/profile/email_confirmation.py
+++ b/osmaxx/profile/email_confirmation.py
@@ -29,7 +29,7 @@ def send_email_confirmation(profile, request):
             'profile/verification_email/body.txt',
             context=dict(
                 token_url=token_url,
-                username=request.user.username,
+                username=user.username,
                 new_email_address=to_email,
                 domain=request.get_host(),
             )

--- a/osmaxx/profile/email_confirmation.py
+++ b/osmaxx/profile/email_confirmation.py
@@ -12,6 +12,7 @@ RATE_LIMIT_SECONDS = 30
 
 def send_email_confirmation(profile, request):
     user = profile.associated_user
+    assert user == request.user
     if cache.get(user.id):
         return
     to_email = profile.unverified_email

--- a/osmaxx/profile/email_confirmation.py
+++ b/osmaxx/profile/email_confirmation.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 RATE_LIMIT_SECONDS = 30
 
 
-def send_email_confirmation(request, profile):
+def send_email_confirmation(profile, request):
     if cache.get(profile.associated_user.id):
         return
     to_email = profile.unverified_email

--- a/osmaxx/profile/email_confirmation.py
+++ b/osmaxx/profile/email_confirmation.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.contrib import messages
+from django.core.cache import cache
+from django.core.mail import send_mail
+from django.template.defaultfilters import urlencode
+from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+
+
+def _send_email_verification(rate_limit_seconds, request, profile):
+    if cache.get(profile.associated_user.id):
+        return
+    to_email = profile.unverified_email
+    if to_email:
+        cache.set(profile.associated_user.id, 'dummy value', timeout=rate_limit_seconds)
+        user_administrator_email = settings.OSMAXX['ACCOUNT_MANAGER_EMAIL']
+        token = profile.activation_key()
+        token_url = '{}?token={}'.format(
+            request.build_absolute_uri(reverse('profile:activation')), urlencode(token)
+        )
+        subject = render_to_string('profile/verification_email/subject.txt', context={}).strip()
+        subject = ''.join(subject.splitlines())
+        message = render_to_string(
+            'profile/verification_email/body.txt',
+            context=dict(
+                token_url=token_url,
+                username=request.user.username,
+                new_email_address=to_email,
+                domain=request.get_host(),
+            )
+        )
+        send_mail(
+            subject=subject,
+            message=message,
+            from_email=user_administrator_email,
+            recipient_list=[to_email],
+        )
+        messages.add_message(
+            request, messages.INFO, _('To activate your email, click the link in the confirmation email.')
+        )

--- a/osmaxx/profile/email_confirmation.py
+++ b/osmaxx/profile/email_confirmation.py
@@ -11,11 +11,12 @@ RATE_LIMIT_SECONDS = 30
 
 
 def send_email_confirmation(profile, request):
-    if cache.get(profile.associated_user.id):
+    user = profile.associated_user
+    if cache.get(user.id):
         return
     to_email = profile.unverified_email
     if to_email:
-        cache.set(profile.associated_user.id, 'dummy value', timeout=RATE_LIMIT_SECONDS)
+        cache.set(user.id, 'dummy value', timeout=RATE_LIMIT_SECONDS)
         user_administrator_email = settings.OSMAXX['ACCOUNT_MANAGER_EMAIL']
         token = profile.activation_key()
         token_url = '{}?token={}'.format(

--- a/osmaxx/profile/email_confirmation.py
+++ b/osmaxx/profile/email_confirmation.py
@@ -10,7 +10,7 @@ from django.utils.translation import ugettext as _
 RATE_LIMIT_SECONDS = 30
 
 
-def _send_email_verification(request, profile):
+def send_email_confirmation(request, profile):
     if cache.get(profile.associated_user.id):
         return
     to_email = profile.unverified_email

--- a/osmaxx/profile/models.py
+++ b/osmaxx/profile/models.py
@@ -5,6 +5,8 @@ from django.core import signing
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
+from osmaxx.profile.email_confirmation import send_email_confirmation
+
 
 class Profile(models.Model):
     REGISTRATION_VERIFICATION_TIMEOUT_DAYS = 2
@@ -21,6 +23,9 @@ class Profile(models.Model):
             obj=self._username_email_dict(),
             salt=self.PROFILE_SALT)
         return key
+
+    def request_email_address_confirmation(self, request):
+        send_email_confirmation(profile=self, request=request)
 
     def validate_key(self, activation_key):
         try:

--- a/osmaxx/profile/views.py
+++ b/osmaxx/profile/views.py
@@ -7,7 +7,6 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views import generic
 
-from osmaxx.profile.email_confirmation import send_email_confirmation
 from osmaxx.profile.forms import ProfileForm
 from osmaxx.profile.models import Profile
 
@@ -35,7 +34,7 @@ class ProfileView(LoginRequiredMixin, generic.UpdateView):
             )
         if self.is_new_user():
             self._move_email_from_user_to_profile(user, profile)
-            send_email_confirmation(self.request, profile)
+            profile.request_email_address_confirmation(self.request)
         else:
             self._ensure_profile_has_email(profile, user)
         user.refresh_from_db()
@@ -52,7 +51,7 @@ class ProfileView(LoginRequiredMixin, generic.UpdateView):
         if isinstance(response, HttpResponseRedirect):  # successful form validation
             profile = Profile.objects.get(associated_user=self.request.user)
             if not profile.has_validated_email():
-                send_email_confirmation(self.request, profile=profile)
+                profile.request_email_address_confirmation(self.request)
         return response
 
     def _ensure_profile_has_email(self, profile, user):
@@ -101,7 +100,7 @@ class ResendVerificationEmail(LoginRequiredMixin, generic.RedirectView):
 
     def get(self, request, *args, **kwargs):
         profile = Profile.objects.get(associated_user=self.request.user)
-        send_email_confirmation(self.request, profile=profile)
+        profile.request_email_address_confirmation(self.request)
         return super().get(request, *args, **kwargs)
 
 

--- a/osmaxx/profile/views.py
+++ b/osmaxx/profile/views.py
@@ -12,11 +12,7 @@ from osmaxx.profile.forms import ProfileForm
 from osmaxx.profile.models import Profile
 
 
-class SendVerificationEmailMixin(object):
-    pass
-
-
-class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.UpdateView):
+class ProfileView(LoginRequiredMixin, generic.UpdateView):
     form_class = ProfileForm
     template_name = 'profile/profile_edit.html'
 
@@ -80,7 +76,7 @@ class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.Update
         return reverse('profile:edit_view')
 
 
-class ActivationView(SendVerificationEmailMixin, LoginRequiredMixin, generic.UpdateView):
+class ActivationView(LoginRequiredMixin, generic.UpdateView):
     error_msg = _('Verification token too old or invalid. Please resend the confirmation email and try again.')
 
     def get(self, request, *args, **kwargs):
@@ -99,7 +95,7 @@ class ActivationView(SendVerificationEmailMixin, LoginRequiredMixin, generic.Upd
         return redirect(reverse('profile:edit_view'))
 
 
-class ResendVerificationEmail(SendVerificationEmailMixin, LoginRequiredMixin, generic.RedirectView):
+class ResendVerificationEmail(LoginRequiredMixin, generic.RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         return reverse('profile:edit_view')
 

--- a/osmaxx/profile/views.py
+++ b/osmaxx/profile/views.py
@@ -1,54 +1,19 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.core.cache import cache
-from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
-from django.template.defaultfilters import urlencode
-from django.template.loader import render_to_string
 from django.utils.translation import ugettext as _
 from django.views import generic
 
+from osmaxx.profile.email_confirmation import _send_email_verification
 from osmaxx.profile.forms import ProfileForm
 from osmaxx.profile.models import Profile
 
 
 class SendVerificationEmailMixin(object):
     RATE_LIMIT_SECONDS = 30
-
-    def _send_email_verification(self, profile):
-        if cache.get(profile.associated_user.id):
-            return
-        to_email = profile.unverified_email
-        if to_email:
-            cache.set(profile.associated_user.id, 'dummy value', timeout=self.RATE_LIMIT_SECONDS)
-            user_administrator_email = settings.OSMAXX['ACCOUNT_MANAGER_EMAIL']
-            token = profile.activation_key()
-            token_url = '{}?token={}'.format(
-                self.request.build_absolute_uri(reverse('profile:activation')), urlencode(token)
-            )
-            subject = render_to_string('profile/verification_email/subject.txt', context={}).strip()
-            subject = ''.join(subject.splitlines())
-            message = render_to_string(
-                'profile/verification_email/body.txt',
-                context=dict(
-                    token_url=token_url,
-                    username=self.request.user.username,
-                    new_email_address=to_email,
-                    domain=self.request.get_host(),
-                )
-            )
-            send_mail(
-                subject=subject,
-                message=message,
-                from_email=user_administrator_email,
-                recipient_list=[to_email],
-            )
-            messages.add_message(
-                self.request, messages.INFO, _('To activate your email, click the link in the confirmation email.')
-            )
 
 
 class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.UpdateView):
@@ -74,7 +39,7 @@ class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.Update
             )
         if self.is_new_user():
             self._move_email_from_user_to_profile(user, profile)
-            self._send_email_verification(profile)
+            _send_email_verification(self.RATE_LIMIT_SECONDS, self.request, profile)
         else:
             self._ensure_profile_has_email(profile, user)
         user.refresh_from_db()
@@ -91,7 +56,7 @@ class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.Update
         if isinstance(response, HttpResponseRedirect):  # successful form validation
             profile = Profile.objects.get(associated_user=self.request.user)
             if not profile.has_validated_email():
-                self._send_email_verification(profile=profile)
+                _send_email_verification(self.RATE_LIMIT_SECONDS, self.request, profile=profile)
         return response
 
     def _ensure_profile_has_email(self, profile, user):
@@ -140,7 +105,7 @@ class ResendVerificationEmail(SendVerificationEmailMixin, LoginRequiredMixin, ge
 
     def get(self, request, *args, **kwargs):
         profile = Profile.objects.get(associated_user=self.request.user)
-        self._send_email_verification(profile=profile)
+        _send_email_verification(self.RATE_LIMIT_SECONDS, self.request, profile=profile)
         return super().get(request, *args, **kwargs)
 
 

--- a/osmaxx/profile/views.py
+++ b/osmaxx/profile/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.utils.translation import ugettext as _
 from django.views import generic
 
-from osmaxx.profile.email_confirmation import _send_email_verification
+from osmaxx.profile.email_confirmation import send_email_confirmation
 from osmaxx.profile.forms import ProfileForm
 from osmaxx.profile.models import Profile
 
@@ -35,7 +35,7 @@ class ProfileView(LoginRequiredMixin, generic.UpdateView):
             )
         if self.is_new_user():
             self._move_email_from_user_to_profile(user, profile)
-            _send_email_verification(self.request, profile)
+            send_email_confirmation(self.request, profile)
         else:
             self._ensure_profile_has_email(profile, user)
         user.refresh_from_db()
@@ -52,7 +52,7 @@ class ProfileView(LoginRequiredMixin, generic.UpdateView):
         if isinstance(response, HttpResponseRedirect):  # successful form validation
             profile = Profile.objects.get(associated_user=self.request.user)
             if not profile.has_validated_email():
-                _send_email_verification(self.request, profile=profile)
+                send_email_confirmation(self.request, profile=profile)
         return response
 
     def _ensure_profile_has_email(self, profile, user):
@@ -101,7 +101,7 @@ class ResendVerificationEmail(LoginRequiredMixin, generic.RedirectView):
 
     def get(self, request, *args, **kwargs):
         profile = Profile.objects.get(associated_user=self.request.user)
-        _send_email_verification(self.request, profile=profile)
+        send_email_confirmation(self.request, profile=profile)
         return super().get(request, *args, **kwargs)
 
 

--- a/osmaxx/profile/views.py
+++ b/osmaxx/profile/views.py
@@ -13,7 +13,7 @@ from osmaxx.profile.models import Profile
 
 
 class SendVerificationEmailMixin(object):
-    RATE_LIMIT_SECONDS = 30
+    pass
 
 
 class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.UpdateView):
@@ -39,7 +39,7 @@ class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.Update
             )
         if self.is_new_user():
             self._move_email_from_user_to_profile(user, profile)
-            _send_email_verification(self.RATE_LIMIT_SECONDS, self.request, profile)
+            _send_email_verification(self.request, profile)
         else:
             self._ensure_profile_has_email(profile, user)
         user.refresh_from_db()
@@ -56,7 +56,7 @@ class ProfileView(SendVerificationEmailMixin, LoginRequiredMixin, generic.Update
         if isinstance(response, HttpResponseRedirect):  # successful form validation
             profile = Profile.objects.get(associated_user=self.request.user)
             if not profile.has_validated_email():
-                _send_email_verification(self.RATE_LIMIT_SECONDS, self.request, profile=profile)
+                _send_email_verification(self.request, profile=profile)
         return response
 
     def _ensure_profile_has_email(self, profile, user):
@@ -105,7 +105,7 @@ class ResendVerificationEmail(SendVerificationEmailMixin, LoginRequiredMixin, ge
 
     def get(self, request, *args, **kwargs):
         profile = Profile.objects.get(associated_user=self.request.user)
-        _send_email_verification(self.RATE_LIMIT_SECONDS, self.request, profile=profile)
+        _send_email_verification(self.request, profile=profile)
         return super().get(request, *args, **kwargs)
 
 

--- a/tests/profile/test_profile_view.py
+++ b/tests/profile/test_profile_view.py
@@ -78,7 +78,7 @@ def test_email_change(authorized_client):
 
 @pytest.mark.django_db()
 def test_mail_sent_only_once_within_rate_limit(authenticated_client):
-    with patch('osmaxx.profile.views.send_mail') as send_mail:
+    with patch('osmaxx.profile.email_confirmation.send_mail') as send_mail:
         assert send_mail.call_count == 0
         authenticated_client.get(reverse('profile:edit_view'))
         assert send_mail.call_count == 1

--- a/tests/profile/test_resend_verfication_email_view.py
+++ b/tests/profile/test_resend_verfication_email_view.py
@@ -10,7 +10,7 @@ def test_resend_verification_page_redirects_when_called_without_user(client):
 
 
 def test_resend_verification_page_sends_mail_with_profile(authorized_client, valid_profile):
-    with patch('osmaxx.profile.views.send_mail') as send_mail:
+    with patch('osmaxx.profile.email_confirmation.send_mail') as send_mail:
         assert send_mail.call_count == 0
         response = authorized_client.get(reverse('profile:resend_verification'), follow=True)
         assert response.status_code == 200
@@ -18,8 +18,8 @@ def test_resend_verification_page_sends_mail_with_profile(authorized_client, val
 
 
 def test_resend_verification_page_limits_click_ratio(authorized_client, valid_profile):
-    with patch('osmaxx.profile.views.send_mail') as send_mail:
-        with patch('osmaxx.profile.views.cache') as cache:
+    with patch('osmaxx.profile.email_confirmation.send_mail') as send_mail:
+        with patch('osmaxx.profile.email_confirmation.cache') as cache:
             cache.get.return_value = None
             assert send_mail.call_count == 0
             authorized_client.get(reverse('profile:resend_verification'), follow=True)


### PR DESCRIPTION
Alternative to #849 

While I like this functionality being accessed through the `Profile` instance, I felt like the implementation was too "view-y" and not enough "model-y" to belong into the model class, so I've made the method delegate to a free function in a new module.

I'm wondering that's good or whether a model mixin would be a better idea or whether it should just be put into the model proper regardless.