### PR TITLE
workaround #771: unescape HTML after rendering plain text email

### DIFF
--- a/osmaxx/excerptexport/models/extraction_order.py
+++ b/osmaxx/excerptexport/models/extraction_order.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch.dispatcher import receiver
 from django.template.loader import render_to_string
+from django.utils.text import unescape_entities
 from django.utils.translation import ugettext_lazy as _
 
 from osmaxx.conversion.converters.converter_gis.detail_levels import DETAIL_LEVEL_CHOICES, DETAIL_LEVEL_ALL
@@ -86,10 +87,12 @@ class ExtractionOrder(models.Model):
             successful_exports_count=self.exports.filter(output_file__isnull=False).count(),
             failed_exports_count=self.exports.filter(output_file__isnull=True).count(),
         )
-        return render_to_string(
-            'excerptexport/email/all_exports_of_extraction_order_done_subject.txt',
-            context=view_context,
-        ).strip()
+        return unescape_entities(
+            render_to_string(
+                'excerptexport/email/all_exports_of_extraction_order_done_subject.txt',
+                context=view_context,
+            ).strip()
+        )  # HACK: calling unescape_entities as workaround for https://github.com/geometalab/osmaxx/issues/771
 
     def _get_all_exports_done_mail_body(self, incoming_request):
         view_context = dict(
@@ -98,10 +101,12 @@ class ExtractionOrder(models.Model):
             failed_exports=self.exports.filter(output_file__isnull=True),
             request=incoming_request,
         )
-        return render_to_string(
-            'excerptexport/email/all_exports_of_extraction_order_done_body.txt',
-            context=view_context,
-        ).strip()
+        return unescape_entities(
+            render_to_string(
+                'excerptexport/email/all_exports_of_extraction_order_done_body.txt',
+                context=view_context,
+            ).strip()
+        )  # HACK: calling unescape_entities as workaround for https://github.com/geometalab/osmaxx/issues/771
 
 
 @receiver(post_save, sender=ExtractionOrder)

--- a/tests/excerptexport/models/test_plain_text_email_rendering.py
+++ b/tests/excerptexport/models/test_plain_text_email_rendering.py
@@ -1,0 +1,20 @@
+from django.contrib.auth import get_user_model
+
+from osmaxx.excerptexport.models import ExtractionOrder, Excerpt
+from osmaxx.utilities.shortcuts import Emissary
+
+from hamcrest import contains_string, match_equality
+
+
+def test_send_email_if_all_exports_done_keeps_special_characters_unescaped(mocker, rf):
+    User = get_user_model()  # noqa
+    extraction_order = ExtractionOrder(orderer=User(), excerpt=Excerpt(name='foo & bar'))
+    incoming_request = rf.get('')
+    im = mocker.patch.object(Emissary, 'inform_mail')
+
+    extraction_order.send_email_if_all_exports_done(incoming_request)
+
+    im.assert_called_once_with(
+        subject=match_equality(contains_string('foo & bar')),
+        mail_body=match_equality(contains_string('foo & bar')),
+    )


### PR DESCRIPTION
connected to #771 (not a final solution, just a hacky workaround)

The added test is the same as in WIP commit 8dda7f54cbc76e17f529b40675ada0a147b2d851 of the (hopefully) final solution that'll become available with Djagno 2.0