### PR TITLE
use build-in os.scandir only

### DIFF
--- a/osmaxx/conversion/converters/utils.py
+++ b/osmaxx/conversion/converters/utils.py
@@ -4,12 +4,7 @@ import subprocess
 import uuid
 import zipfile
 
-# Use the built-in version of scandir if possible, otherwise
-# use the scandir module version
-try:
-    from os import scandir
-except ImportError:
-    from scandir import scandir
+from os import scandir
 
 logger = logging.getLogger(__name__)
 

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -93,7 +93,6 @@ requests==2.13.0
 requirements-detector==0.5.2  # via prospector
 rq==0.7.1
 ruamel.yaml==0.14.11
-scandir==1.5
 scipy==0.19.0
 selenium==3.4.1           # via pytest-selenium
 setoptconf==0.2.0         # via prospector

--- a/requirements.in
+++ b/requirements.in
@@ -31,8 +31,6 @@ SQLAlchemy-Utils
 sqlalchemy-views
 GeoAlchemy2
 furl
-# fallback for python < 3.5
-scandir
 
 # Test requirements
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,7 +91,6 @@ requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.13.0
 requirements-detector==0.5.2  # via prospector
 rq==0.7.1
-scandir==1.5
 scipy==0.19.0
 selenium==3.4.1           # via pytest-selenium
 setoptconf==0.2.0         # via prospector


### PR DESCRIPTION
as we don't support Python < 3.5 anymore