### PR TITLE
(minor) fix typo "OMSaxx"

### DIFF
--- a/osmaxx/core/templates/pages/downloads.html
+++ b/osmaxx/core/templates/pages/downloads.html
@@ -66,7 +66,7 @@
         <h3>Styles</h3>
         <h4>QGIS</h4>
         <p>
-            A QGIS project file is being delivered with every export, matching the exported data containing the OMSaxx
+            A QGIS project file is being delivered with every export, matching the exported data containing the OSMaxx
             default style. The file should be opened in the folder where it can be found:  <code>&lt;<i>unzipped_folder</i>&gt;/symbology/QGIS/</code>.
         </p>
         <h4>ESRI ArcMap</h4>


### PR DESCRIPTION
in download page: https://osmaxx.hsr.ch/pages/downloads/ (section Styles -> QGIS)