### PR TITLE
refactoring: rename POSTGIS_MAJOR to POSTGIS_VERSION

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -24,7 +24,7 @@ RUN APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=DontWarn \
     apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 ENV PG_MAJOR 11
-ENV POSTGIS_MAJOR 2.5
+ENV POSTGIS_VERSION 2.5
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list \
     && DEBIAN_FRONTEND=noninteractive apt-get update \
@@ -33,8 +33,8 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main' $PG_MAJ
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         postgresql-${PG_MAJOR} \
         postgresql-contrib-${PG_MAJOR} \
-        postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR} \
-        postgresql-${PG_MAJOR}-postgis-${POSTGIS_MAJOR}-scripts \
+        postgresql-${PG_MAJOR}-postgis-${POSTGIS_VERSION} \
+        postgresql-${PG_MAJOR}-postgis-${POSTGIS_VERSION}-scripts \
         postgresql-server-dev-${PG_MAJOR} \
         postgresql-contrib-${PG_MAJOR} \
     && DEBIAN_FRONTEND=noninteractive apt-get clean \


### PR DESCRIPTION
because it holds both, the major and minor component of the PostGIS version